### PR TITLE
Add auth metadata key to address #47

### DIFF
--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -562,6 +562,20 @@ definitions:
             A set of key-value pairs that represent metadata provided by the uploader.
   AuthorizationMetadata:
     type: object
+    properties:
+        provider:
+          type: string
+          description: |-
+            The auth provider, e.g. auth0, google, etc.
+        auth_type:
+          type: string
+          description: |-
+            The auth standard being used to make data available. For example, 'OAuth2.0'.
+        auth_url:
+          type: string
+          description: |- 
+            The URL where the auth service is located, for example, a URL to get an OAuth
+            token.
     additionalProperties: true
     description: |-
             OPTIONAL

--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -560,6 +560,13 @@ definitions:
     description: |-
             OPTIONAL
             A set of key-value pairs that represent metadata provided by the uploader.
+  AuthorizationMetadata:
+    type: object
+    additionalProperties: true
+    description: |-
+            OPTIONAL
+            A set of key-value pairs that represent sufficient metadata to be granted 
+            access to a resource.
   Checksum:
     type: object
     required: ['checksum']
@@ -899,6 +906,8 @@ definitions:
         $ref: '#/definitions/SystemMetadata'
       user_metadata:
         $ref: '#/definitions/UserMetadata'
+      authorization_metadata:
+        $ref: '#/definitions/AuthorizationMetadata'
   UpdateDataBundleRequest:
     type: object
     required: ['data_bundle']

--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -563,10 +563,6 @@ definitions:
   AuthorizationMetadata:
     type: object
     properties:
-        provider:
-          type: string
-          description: |-
-            The auth provider, e.g. auth0, google, etc.
         auth_type:
           type: string
           description: |-
@@ -580,7 +576,8 @@ definitions:
     description: |-
             OPTIONAL
             A set of key-value pairs that represent sufficient metadata to be granted 
-            access to a resource.
+            access to a resource. It may be helpful to provide details about a specific
+            provider, for example.
   Checksum:
     type: object
     required: ['checksum']


### PR DESCRIPTION
This is an attempt to address #47 by accepting a suggestion provided by @mfiume.

This will allow services to provide optional metadata fields for each URL under the `authorization_metadata` key. [As mentioned in](https://github.com/ga4gh/data-object-service-schemas/issues/47#issuecomment-402524882) #47 , we need to determine in practice which keys will be necessary, however, adding this key will provide a single place for those metadata to be found.

The problem being addressed is to allow downstream software that uses Data Objects to be able to delegate auth concerns as necessary. For example, once a client has resolved the URL and auth metadata for a Data Object, a downstream WES would like to be able to request authorization for accessing that object from the underlying object store as necessary.