### PR TITLE
Generate and test OpenAPI and Swagger schemas (closes #184)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,9 @@ jobs:
 before_install:
 - python setup.py sdist
 - pip install dist/ga4gh_dos_schemas-*.tar.gz
+- npm install -g swagger2openapi
 
 script:
+- make schemas
 - nosetests python/
 - ga4gh_dos_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flake8==3.5.0
 nose==1.3.7
 Sphinx==1.7.4
+openapi-spec-validator==0.2.4


### PR DESCRIPTION
* Adds `test_openapi_schema_validity`, which uses `openapi_spec_validator` to validate the generated OpenAPI schema if it is present. Skipped otherwise.
* Adds `test_smartapi_schema_validity`, which uses the remote SmartAPI validation API to validate the generate SmartAPI schema if it is present. Skipped otherwise. (This one is a little contrived, but I've included it in the PR for propriety.)
* Updates Travis test harness and development requirements accordingly