### PR TITLE
Data Bundles v0.1 Schema (1/2)

### DIFF
--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -258,7 +258,6 @@ definitions:
       - id
       - size
       - created
-      - updated
       - version
       - checksums
       - contents

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -42,7 +42,7 @@ paths:
         '200':
           description: Successfully found the Data Bundle.
           schema:
-            $ref: '#/definitions/GetBundleResponse'
+            $ref: '#/definitions/Bundle'
         '400':
           description: The request is malformed.
           schema:
@@ -51,12 +51,12 @@ paths:
           description: The request is unauthorized.
           schema:
             $ref: '#/definitions/ErrorResponse'
-        '404':
-          description: The requested Data Bundle wasn't found.
-          schema:
-            $ref: '#/definitions/ErrorResponse'
         '403':
           description: The requester is not authorized to perform this action.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        '404':
+          description: The requested Data Bundle wasn't found.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '500':
@@ -194,57 +194,70 @@ definitions:
           sha512
   Bundle:
     type: object
-    required: ['id', 'object_ids', 'created', 'updated', 'version', 'checksums']
     properties:
       id:
         type: string
-        description: |-
+        description: >-
           An identifier, unique to this Data Bundle
       object_ids:
         type: array
         items:
           type: string
-        description: |-
+        description: >-
           The list of Data Objects that this Data Bundle contains.
       created:
         type: string
         format: date-time
-        description: |-
+        description: >-
           Timestamp of object creation in RFC3339.
       updated:
         type: string
         format: date-time
-        description: |-
-          Timestamp of update in RFC3339, identical to create timestamp in systems
-          that do not support updates.
+        description: >-
+          Timestamp of update in RFC3339, identical to create timestamp in
+          systems that do not support updates.
       version:
         type: string
-        description: |-
-          A string representing a version, some systems may use checksum, a RFC3339
-          timestamp, or incrementing version number. For systems that do not support
-          versioning please use your update timestamp as your version.
+        description: >-
+          A string representing a version, some systems may use checksum, a
+          RFC3339 timestamp, or incrementing version number. For systems that do not
+          support versioning please use your update timestamp as your version.
+      mime-type:
+        type: string
+        description: >-
+          A string providing the mime-type of the Data Bundle.
+          For example, "application/json".
       checksums:
         type: array
-        items:
-          $ref: '#/definitions/Checksum'
-        description: |-
+        description: >-
           At least one checksum must be provided.
           The Data Bundle checksum is computed over all the checksums of the
           Data Objects that bundle contains.
-      description:
-        type: string
-        description: |-
-          A human readable description.
-      aliases:
+        items:
+          $ref: '#/definitions/Checksum'
+      access_methods:
         type: array
         items:
+          $ref: '#/definitions/AccessMethod'
+      description:
+        type: string
+        description: A human readable description.
+      aliases:
+        type: array
+        description: A list of strings that can be used to identify this Data Bundle.
+        items:
           type: string
-        description: |-
-          A list of strings that can be used to identify this Data Bundle.
-      system_metadata:
-        $ref: '#/definitions/SystemMetadata'
-      user_metadata:
-        $ref: '#/definitions/UserMetadata'
+      contents:
+        type: array
+        items:
+          $ref: '#/definitions/BundleObjects'
+    required:
+      - id
+      - size
+      - created
+      - updated
+      - version
+      - checksums
   Object:
     type: object
     required: ['id', 'size', 'created', 'checksums', 'access_methods']
@@ -308,11 +321,6 @@ definitions:
           These aliases can be used to represent the Data Object's location in
           a directory (e.g. "bucket/folder/file.name") to make Data Objects
           more discoverable. They might also be used to represent
-  GetBundleResponse:
-    type: object
-    properties:
-      bundle:
-        $ref: '#/definitions/Bundle'
   GetObjectResponse:
     type: object
     required: ['object']
@@ -396,3 +404,15 @@ definitions:
       license:
         type: object
         description: License information for the exposed API
+  BundleObjects:
+    type: object
+    properties:
+      name:
+        type: string
+      id:
+        type: string
+    required:
+      - name
+      - id
+tags:
+  - name: DataRepositoryService

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -216,7 +216,7 @@ definitions:
         type: string
         description: >-
           A string providing the mime-type of the Data Bundle.
-          For example, "application/json".
+        example: 'application/json'
       checksums:
         type: array
         description: >-

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -222,7 +222,7 @@ definitions:
         description: >-
           At least one checksum must be provided.
           The Data Bundle checksum is computed over a sorted concatenation of all the 
-          checksums of the Data Objects that bundle contains. The list of Data
+          checksums within the top-level 'contents' of the Bundle (not recursive). The list of Data
           Object checksums are sorted alphabetically (hex-code) before concatenation and a further
           checksum performed on the concated binary value. Example below:
           Data Ojects:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -418,8 +418,8 @@ definitions:
       id:
         type: string
         description: >-
-          This represents the DRS identifier that may point to a Data Object
-          or another Data Bundle that will need to be recursed.
+          This represents the DRS identifier URI that may point to a Data
+          Object or another Data Bundle that will need to be recursed.
       type:
         type: string
         enum:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -186,6 +186,11 @@ definitions:
         type: string
         description: >-
           An identifier, unique to this Data Bundle
+      size:
+        type: string
+        format: int64
+        description: |-
+          The computed cumulated size of all Data Objects in bytes.
       created:
         type: string
         format: date-time

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -160,19 +160,6 @@ securityDefinitions:
     name: Authorization
     in: header
 definitions:
-  SystemMetadata:
-    type: object
-    additionalProperties: true
-    description: |-
-            OPTIONAL
-            These values are reported by the underlying object store.
-            A set of key-value pairs that represent system metadata about the object.
-  UserMetadata:
-    type: object
-    additionalProperties: true
-    description: |-
-            OPTIONAL
-            A set of key-value pairs that represent metadata provided by the uploader.
   Checksum:
     type: object
     required: ['checksum']

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -194,7 +194,7 @@ definitions:
         type: string
         format: int64
         description: |-
-          The cumulative size of all (recursive) Data Objects in bytes.
+          The cumulative size of all Data Objects and Bundles (within contents) in bytes.
       created:
         type: string
         format: date-time

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -418,8 +418,15 @@ definitions:
       id:
         type: string
         description: >-
-          This represents the DRS identifier URI that may point to a Data
+          This represents the DRS identifier that may point to a Data
           Object or another Data Bundle that will need to be recursed.
+      drs_uri:
+        type: array
+        description: >-
+          This represents a list of suggested full DRS identifier URI paths
+          that may used obtain the Data Object or Data Bundle that will need
+          to be recursed. These URIs may be external to this DRS.
+        example: 'drs://example.com/ga4gh/drs/v1/objects/{object_id}'
       type:
         type: string
         enum:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -419,8 +419,18 @@ definitions:
         description: >-
           This represents the DRS identifier that may point to a Data Object
           or another Data Bundle that will need to be recursed.
+      type:
+        type: string
+        enum:
+          - object
+          - bundle
+        description: >-
+          This represents the type of DRS object referenced within this
+          Data Bundle. BundleObject of type bundle will need to be recursed
+          further.
     required:
       - name
       - id
+      - type
 tags:
   - name: DataRepositoryService

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -194,7 +194,8 @@ definitions:
         type: string
         format: int64
         description: |-
-          The cumulative size of all Data Objects and Bundles (within contents) in bytes.
+          The cumulative size of all Data Objects and Bundles listed within
+          contents field in bytes.
       created:
         type: string
         format: date-time

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -253,7 +253,7 @@ definitions:
         description: >-
           The list of Data Objects that this Data Bundle contains.
         items:
-          $ref: '#/definitions/BundleObjects'
+          $ref: '#/definitions/BundleObject'
     required:
       - id
       - size
@@ -406,7 +406,7 @@ definitions:
       license:
         type: object
         description: License information for the exposed API
-  BundleObjects:
+  BundleObject:
     type: object
     properties:
       name:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -238,7 +238,11 @@ definitions:
         description: A human readable description.
       aliases:
         type: array
-        description: A list of strings that can be used to identify this Data Bundle.
+        description: |-
+          A list of strings that can be used to find other metadata 
+          about this Data Bundle from external metadata sources. These
+          aliases can be used to represent the Data Bundle's secondary
+          accession numbers or external GUIDs.
         items:
           type: string
       contents:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -409,6 +409,11 @@ definitions:
     properties:
       name:
         type: string
+        description: >-
+          This represents the Bundle author declared name that must be
+          used when materialising the associated data object and will 
+          override any name directly associated with the object itself.
+          This string MUST NOT contain any slashes.
       id:
         type: string
     required:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -199,12 +199,6 @@ definitions:
         type: string
         description: >-
           An identifier, unique to this Data Bundle
-      object_ids:
-        type: array
-        items:
-          type: string
-        description: >-
-          The list of Data Objects that this Data Bundle contains.
       created:
         type: string
         format: date-time
@@ -249,6 +243,8 @@ definitions:
           type: string
       contents:
         type: array
+        description: >-
+          The list of Data Objects that this Data Bundle contains.
         items:
           $ref: '#/definitions/BundleObjects'
     required:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -258,7 +258,6 @@ definitions:
       - id
       - size
       - created
-      - version
       - checksums
       - contents
   Object:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -425,6 +425,8 @@ definitions:
           that may used obtain the Data Object or Data Bundle that will need
           to be recursed. These URIs may be external to this DRS.
         example: 'drs://example.com/ga4gh/drs/v1/objects/{object_id}'
+        items:
+          type: string
       type:
         type: string
         enum:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -199,19 +199,18 @@ definitions:
         type: string
         format: date-time
         description: >-
-          Timestamp of object creation in RFC3339.
+          Timestamp of Bundle creation in RFC3339.
       updated:
         type: string
         format: date-time
         description: >-
-          Timestamp of update in RFC3339, identical to create timestamp in
+          Timestamp of Bundle update in RFC3339, identical to create timestamp in
           systems that do not support updates.
       version:
         type: string
         description: >-
           A string representing a version, some systems may use checksum, a
-          RFC3339 timestamp, or incrementing version number. For systems that do not
-          support versioning please use your update timestamp as your version.
+          RFC3339 timestamp, or incrementing version number.
       mime-type:
         type: string
         description: >-

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -225,8 +225,19 @@ definitions:
         type: array
         description: >-
           At least one checksum must be provided.
-          The Data Bundle checksum is computed over all the checksums of the
-          Data Objects that bundle contains.
+          The Data Bundle checksum is computed over a sorted concatenation of all the 
+          checksums of the Data Objects that bundle contains. The list of Data
+          Object checksums are sorted alphabetically (hex-code) before concatenation and a further
+          checksum performed on the concated binary value. Example below:
+          Data Ojects:
+            md5(DO1) = 72794b6d30bc86d92e40a1aa65c880b8
+            md5(DO2) = 5e089d29a18954e68a78ee6a3c6edabd
+          Data Bundle:
+          DB1 = md5( concat( sort( md5(DO1), md5(DO2) ) ) )
+              = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
+              = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
+              = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
+              = f7a29a0422e7d870b10839ad6c985079
         items:
           $ref: '#/definitions/Checksum'
       access_methods:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -416,6 +416,9 @@ definitions:
           This string MUST NOT contain any slashes.
       id:
         type: string
+        description: >-
+          This represents the DRS identifier that may point to a Data Object
+          or another Data Bundle that will need to be recursed.
     required:
       - name
       - id

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -211,11 +211,6 @@ definitions:
         description: >-
           A string representing a version, some systems may use checksum, a
           RFC3339 timestamp, or incrementing version number.
-      mime-type:
-        type: string
-        description: >-
-          A string providing the mime-type of the Data Bundle.
-        example: 'application/json'
       checksums:
         type: array
         description: >-

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -258,6 +258,7 @@ definitions:
       - updated
       - version
       - checksums
+      - contents
   Object:
     type: object
     required: ['id', 'size', 'created', 'checksums', 'access_methods']

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -217,9 +217,10 @@ definitions:
         description: >-
           At least one checksum must be provided.
           The Data Bundle checksum is computed over a sorted concatenation of all 
-          the checksums within the top-level 'contents' of the Bundle (not recursive).
-          The list of Data Object or Bundle checksums are sorted alphabetically (hex-code)
-          before concatenation and a further checksum performed on the concatenated value.
+          the checksums (names not included) within the top-level 'contents' of the
+          Bundle (not recursive). The list of Data Object or Bundle checksums are 
+          sorted alphabetically (hex-code) before concatenation and a further checksum
+          is performed on the concatenated checksum value.
           Example below:
           Data Ojects:
             md5(DO1) = 72794b6d30bc86d92e40a1aa65c880b8

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -186,6 +186,10 @@ definitions:
         type: string
         description: >-
           An identifier, unique to this Data Bundle
+      name:
+        type: string
+        description: |-
+          A string that can be optionally used to name a Data Bundle.
       size:
         type: string
         format: int64

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -216,10 +216,11 @@ definitions:
         type: array
         description: >-
           At least one checksum must be provided.
-          The Data Bundle checksum is computed over a sorted concatenation of all the 
-          checksums within the top-level 'contents' of the Bundle (not recursive). The list of Data
-          Object checksums are sorted alphabetically (hex-code) before concatenation and a further
-          checksum performed on the concated binary value. Example below:
+          The Data Bundle checksum is computed over a sorted concatenation of all 
+          the checksums within the top-level 'contents' of the Bundle (not recursive).
+          The list of Data Object or Bundle checksums are sorted alphabetically (hex-code)
+          before concatenation and a further checksum performed on the concatenated value.
+          Example below:
           Data Ojects:
             md5(DO1) = 72794b6d30bc86d92e40a1aa65c880b8
             md5(DO2) = 5e089d29a18954e68a78ee6a3c6edabd

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -230,10 +230,6 @@ definitions:
               = f7a29a0422e7d870b10839ad6c985079
         items:
           $ref: '#/definitions/Checksum'
-      access_methods:
-        type: array
-        items:
-          $ref: '#/definitions/AccessMethod'
       description:
         type: string
         description: A human readable description.

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -194,7 +194,7 @@ definitions:
         type: string
         format: int64
         description: |-
-          The computed cumulated size of all Data Objects in bytes.
+          The cumulative size of all (recursive) Data Objects in bytes.
       created:
         type: string
         format: date-time


### PR DESCRIPTION
Initial commit based on #221.

Advanced expansions i.e. `expand=shallow` & `expand=deep` will have to wait until OAPI3 (for anyOf support)

[Optional] Data Bundle Access URL Method added in #245 