### PR TITLE
Metadata cleanup

### DIFF
--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -226,7 +226,10 @@ definitions:
         items:
           type: string
         description: |-
-          A list of strings that can be used to identify this Data Bundle.
+          A list of strings that can be used to find this Data Bundle.
+          These aliases can be used to represent the Data Bundle's 
+          secondary accession numbers or external GUIDs that may help
+          with the discovery of the Data Bundle.
   Object:
     type: object
     required: ['id', 'size', 'created', 'checksums', 'access_methods']

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -159,19 +159,6 @@ securityDefinitions:
     name: Authorization
     in: header
 definitions:
-  SystemMetadata:
-    type: object
-    additionalProperties: true
-    description: |-
-            OPTIONAL
-            These values are reported by the underlying object store.
-            A set of key-value pairs that represent system metadata about the object.
-  UserMetadata:
-    type: object
-    additionalProperties: true
-    description: |-
-            OPTIONAL
-            A set of key-value pairs that represent metadata provided by the uploader.
   Checksum:
     type: object
     required: ['checksum']

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -161,12 +161,12 @@ securityDefinitions:
 definitions:
   Checksum:
     type: object
-    required: ['checksum']
+    required:
+      - checksum
     properties:
       checksum:
         type: string
-        description: |-
-          The hex-string encoded checksum for the Data.
+        description: 'The hex-string encoded checksum for the data'
       type:
         type: string
         description: |-
@@ -364,7 +364,8 @@ definitions:
         description: The integer representing the HTTP status code (e.g. 200, 404).
   ServiceInfoResponse:
     type: object
-    required: ['version']
+    required:
+      - version
     description: Placeholder for the Info Object
     properties:
       version:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -292,7 +292,7 @@ definitions:
           A list of strings that can be used to find this Data Object.
           These aliases can be used to represent the Data Object's location in
           a directory (e.g. "bucket/folder/file.name") to make Data Objects
-          more discoverable. They might also be used to represent
+          more discoverable.
   GetBundleResponse:
     type: object
     properties:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -289,10 +289,10 @@ definitions:
         items:
           type: string
         description: |-
-          A list of strings that can be used to find this Data Object.
-          These aliases can be used to represent the Data Object's location in
-          a directory (e.g. "bucket/folder/file.name") to make Data Objects
-          more discoverable.
+          A list of strings that can be used to find other metadata 
+          about this Data Object from external metadata sources. These
+          aliases can be used to represent the Data Object's secondary
+          accession numbers or external GUIDs.
   GetBundleResponse:
     type: object
     properties:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -227,10 +227,6 @@ definitions:
           type: string
         description: |-
           A list of strings that can be used to identify this Data Bundle.
-      system_metadata:
-        $ref: '#/definitions/SystemMetadata'
-      user_metadata:
-        $ref: '#/definitions/UserMetadata'
   Object:
     type: object
     required: ['id', 'size', 'created', 'checksums', 'access_methods']

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -188,8 +188,8 @@ definitions:
           will be assumed.
 
           possible values:
-          md5                # most blob stores provide a checksum using this
-          multipart-md5      # multipart uploads provide a specialized tag in S3
+          md5               # most blob stores provide a checksum using this
+          etag              # multipart uploads to blob stores
           sha256
           sha512
   Bundle:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -50,12 +50,12 @@ paths:
           description: The request is unauthorized.
           schema:
             $ref: '#/definitions/ErrorResponse'
-        '404':
-          description: The requested Data Bundle wasn't found.
-          schema:
-            $ref: '#/definitions/ErrorResponse'
         '403':
           description: The requester is not authorized to perform this action.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        '404':
+          description: The requested Data Bundle wasn't found.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '500':
@@ -87,12 +87,12 @@ paths:
           description: The request is unauthorized.
           schema:
             $ref: '#/definitions/ErrorResponse'
-        '404':
-          description: The requested Data Object wasn't found
-          schema:
-            $ref: '#/definitions/ErrorResponse'
         '403':
           description: The requester is not authorized to perform this action.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        '404':
+          description: The requested Data Object wasn't found
           schema:
             $ref: '#/definitions/ErrorResponse'
         '500':

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -243,7 +243,7 @@ definitions:
         description: |-
           A string that can be optionally used to name a Data Object.
       size:
-        type: string
+        type: integer
         format: int64
         description: |-
           The computed size in bytes.

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -3,14 +3,13 @@ basePath: '/ga4gh/drs/v1'
 info:
   title: Data Repository Service
   version: 0.1.0
-  description: https://github.com/ga4gh/data-repository-service-schemas
+  description: 'https://github.com/ga4gh/data-repository-service-schemas'
   contact:
     name: GA4GH Cloud Work Stream
     email: ga4gh-cloud@ga4gh.org
-    x-role: responsible developer
   license:
     name: Apache 2.0
-    url: https://raw.githubusercontent.com/ga4gh/data-repository-service-schemas/master/LICENSE
+    url: 'https://raw.githubusercontent.com/ga4gh/data-repository-service-schemas/master/LICENSE'
 schemes:
   - https
   - http

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -226,10 +226,10 @@ definitions:
         items:
           type: string
         description: |-
-          A list of strings that can be used to find this Data Bundle.
-          These aliases can be used to represent the Data Bundle's 
-          secondary accession numbers or external GUIDs that may help
-          with the discovery of the Data Bundle.
+          A list of strings that can be used to find other metadata 
+          about this Data Bundle from external metadata sources. These
+          aliases can be used to represent the Data Bundle's secondary
+          accession numbers or external GUIDs.
   Object:
     type: object
     required: ['id', 'size', 'created', 'checksums', 'access_methods']


### PR DESCRIPTION
- Merge #243 for proto2openapi cleanup
- Renamed `multipart-md5` to `etag`
- Removed unused `SystemMetadata` and `UserMetadata` definitions