### PR TITLE
Fix bug that causes non-master builds to erase master docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ jobs:
       - "./scripts/stagepages.sh"
       deploy:
         provider: pages
-        skip-cleanup: true
+        skip_cleanup: true
+        keep_history: true
         github-token: $GITHUB_TOKEN
         on:
           all_branches: true

--- a/scripts/fetchpages.sh
+++ b/scripts/fetchpages.sh
@@ -8,16 +8,6 @@ rm -rf .ghpages-tmp
 mkdir -p .ghpages-tmp
 cd .ghpages-tmp
 git clone --depth=1 --branch=gh-pages $REPO_URL .
-if [ "$TRAVIS_BRANCH" == "master" ]; then
 cp -Rn . ../
-else
-# in case it doesn't exist
-mkdir -p preview
-mkdir -p docs
-mkdir -p swagger-ui
-cp -Rn preview ../preview/
-cp -Rn docs ../docs/
-cp -Rn swagger-ui ../swagger-ui/
-fi
 cd ..
 rm -rf .ghpages-tmp

--- a/scripts/stagepages.sh
+++ b/scripts/stagepages.sh
@@ -20,3 +20,5 @@ fi
 
 # do some cleanup, these cause the gh-pages deploy to break
 rm -rf node_modules
+rm -rf web_deploy
+rm -rf spec

--- a/scripts/stagepages.sh
+++ b/scripts/stagepages.sh
@@ -5,7 +5,7 @@ set -v
 
 if [ "$TRAVIS_BRANCH" != "gh-pages" ]; then
   if [ "$TRAVIS_BRANCH" == "master" ]; then
-    branchpath = "."
+    branchpath="."
   else
     branch=$(echo "$TRAVIS_BRANCH" | awk '{print tolower($0)}')
     branchpath="preview/$branch"


### PR DESCRIPTION
I think @natanlao's set up for the docs build in #211 might ultimately be nicer, but has gotten behind and would require some merge conflict resolution. This fix to the `fetchpages` script should work for now (*still need to merge with develop and then master for changes to take full effect*).

I also tweaked the Travis config to preserve history on the gh-pages branch, per discussion with @briandoconnor and @dglazer this morning.