### PR TITLE
 Object / Bundle unification (addresses part of #252)

### DIFF
--- a/docs/asciidoc/front_matter.adoc
+++ b/docs/asciidoc/front_matter.adoc
@@ -19,8 +19,8 @@ Each implementation of DRS can choose its own id scheme, as long as it follows t
 
 DRS v1 supports two types of content:
 
-* an `Object` is like a file -- it's a single blob of bytes
-* a `Bundle` is like a folder -- it's a collection of other DRS content (either objects or bundles)
+* a _blob_ is like a file -- it's a single blob of bytes, represented by an `Object` without a `contents` array
+* a _bundle_ is like a folder -- it's a collection of other DRS content (either blobs or bundles), represented by an `Object` with a `contents` array
 
 === Read-only
 

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -241,9 +241,9 @@ definitions:
         description: >-
           If not set, this `Object` is a single blob.
           
-          If set, this `Object` is a bundle containing the listed `BundleObject` s (some of which may be further nested).
+          If set, this `Object` is a bundle containing the listed `ContentsObject` s (some of which may be further nested).
         items:
-          $ref: '#/definitions/BundleObject'
+          $ref: '#/definitions/ContentsObject'
       description:
         type: string
         description: |-
@@ -341,7 +341,7 @@ definitions:
       license:
         type: object
         description: License information for the exposed API
-  BundleObject:
+  ContentsObject:
     type: object
     properties:
       name:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -198,23 +198,34 @@ definitions:
         minItems: 1
         items:
           $ref: '#/definitions/Checksum'
-        description: |-
+        description: >-
           The checksum of the `Object`. At least one checksum must be provided.
+          
           For blobs, the checksum is computed over the bytes in the blob.
+          
           
           For bundles, the checksum is computed over a sorted concatenation of the 
           checksums of its top-level contained objects (not recursive, names not included).
           The list of checksums is sorted alphabetically (hex-code) before concatenation
           and a further checksum is performed on the concatenated checksum value.
           
+          
           For example, if a bundle contains blobs with the following checksums:
+          
             md5(blob1) = 72794b6d30bc86d92e40a1aa65c880b8
-            md5(blob2) = 5e089d29a18954e68a78ee6a3c6edabd       
+            
+            md5(blob2) = 5e089d29a18954e68a78ee6a3c6edabd   
+            
           Then the checksum of the bundle is:
+          
             md5( concat( sort( md5(blob1), md5(blob2) ) ) )
+            
               = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
+              
               = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
+              
               = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
+              
               = f7a29a0422e7d870b10839ad6c985079
       access_methods:
         type: array

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -35,45 +35,6 @@ paths:
       tags:
         - DataRepositoryService
       x-swagger-router-controller: ga4gh.drs.server
-  '/bundles/{bundle_id}':
-    get:
-      summary: Get info about a Data Bundle.
-      description: >-
-        Returns bundle metadata, and a list of ids that can be used to fetch bundle contents.
-      operationId: GetBundle
-      responses:
-        '200':
-          description: The Data Bundle was found successfully.
-          schema:
-            $ref: '#/definitions/Bundle'
-        '400':
-          description: The request is malformed.
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: The request is unauthorized.
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: The requester is not authorized to perform this action.
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: The requested Data Bundle wasn't found.
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: An unexpected error occurred.
-          schema:
-            $ref: '#/definitions/Error'
-      parameters:
-        - name: bundle_id
-          in: path
-          required: true
-          type: string
-      tags:
-        - DataRepositoryService
-      x-swagger-router-controller: ga4gh.drs.server
   '/objects/{object_id}':
     get:
       summary: Get info about a Data Object.
@@ -101,7 +62,6 @@ paths:
           description: The requested Data Object wasn't found
           schema:
             $ref: '#/definitions/Error'
-
         '500':
           description: An unexpected error occurred.
           schema:
@@ -192,83 +152,9 @@ definitions:
           etag              # multipart uploads to blob stores
           sha256
           sha512
-  Bundle:
-    type: object
-    required: ['id', 'size', 'created', 'checksums', 'contents']
-    properties:
-      id:
-        type: string
-        description: >-
-          An identifier unique to this Data Bundle.
-      name:
-        type: string
-        description: >-
-          A string that can be used to name a Data Bundle.
-      size:
-        type: string
-        format: int64
-        description: >-
-          The cumulative size, in bytes, of all Data Objects and Bundles listed in
-          the `contents` field.
-      created:
-        type: string
-        format: date-time
-        description: >-
-          Timestamp of Bundle creation in RFC3339.
-      updated:
-        type: string
-        format: date-time
-        description: >-
-          Timestamp of Bundle update in RFC3339, identical to create timestamp in
-          systems that do not support updates.
-      version:
-        type: string
-        description: >-
-          A string representing a version. (Some systems may use checksum, a
-          RFC3339 timestamp, or an incrementing version number.)
-      checksums:
-        type: array
-        description: |-
-          The checksum of the Data Bundle. At least one checksum must be provided.
-          
-          The Data Bundle checksum is computed over a sorted concatenation of all 
-          the checksums (names not included) within the top-level 'contents' of the
-          Bundle (not recursive). The list of Data Object or Bundle checksums are 
-          sorted alphabetically (hex-code) before concatenation and a further checksum
-          is performed on the concatenated checksum value.
-          Example below:
-          Data Ojects:
-            md5(DO1) = 72794b6d30bc86d92e40a1aa65c880b8
-            md5(DO2) = 5e089d29a18954e68a78ee6a3c6edabd
-          Data Bundle:
-          DB1 = md5( concat( sort( md5(DO1), md5(DO2) ) ) )
-              = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
-              = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
-              = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
-              = f7a29a0422e7d870b10839ad6c985079
-        items:
-          $ref: '#/definitions/Checksum'
-      description:
-        type: string
-        description: A human readable description of the Data Bundle.
-      aliases:
-        type: array
-        description: >-
-          A list of strings that can be used to find other metadata 
-          about this Data Bundle from external metadata sources. These
-          aliases can be used to represent the Data Bundle's secondary
-          accession numbers or external GUIDs.
-        items:
-          type: string
-      contents:
-        type: array
-        description: >-
-          The list of Data Objects and Data Bundles contained by this Data Bundle.
-        items:
-          $ref: '#/definitions/BundleObject'
   Object:
     type: object
-    required: ['id', 'size', 'created', 'checksums', 'access_methods']
+    required: ['id', 'size', 'created', 'checksums']
     properties:
       id:
         type: string
@@ -282,7 +168,8 @@ definitions:
         type: integer
         format: int64
         description: |-
-          The object size in bytes.
+          For single items, the object size in bytes.
+          For bundles, the cumulative size, in bytes, of everything listed in the `contents` field.
       created:
         type: string
         format: date-time
@@ -292,7 +179,7 @@ definitions:
         type: string
         format: date-time
         description: >-
-          Timestamp of Object update in RFC3339, identical to create timestamp in systems
+          Timestamp of object update in RFC3339, identical to create timestamp in systems
           that do not support updates.
       version:
         type: string
@@ -310,6 +197,23 @@ definitions:
           $ref: '#/definitions/Checksum'
         description: |-
           The checksum of the Data Object. At least one checksum must be provided.
+
+          For single items, the checksum is computed over the bytes in the item.
+          For bundles, the checksum is computed over a sorted concatenation of all 
+          the checksums (names not included) within the top-level `contents` field
+          (not recursive). The list of checksums are
+          sorted alphabetically (hex-code) before concatenation and a further checksum
+          is performed on the concatenated checksum value.
+          Example below:
+          Data Objects:
+            md5(DO1) = 72794b6d30bc86d92e40a1aa65c880b8
+            md5(DO2) = 5e089d29a18954e68a78ee6a3c6edabd
+          Data Bundle:
+          DB1 = md5( concat( sort( md5(DO1), md5(DO2) ) ) )
+              = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
+              = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
+              = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
+              = f7a29a0422e7d870b10839ad6c985079
       access_methods:
         type: array
         minItems: 1
@@ -317,6 +221,14 @@ definitions:
           $ref: '#/definitions/AccessMethod'
         description: |-
           The list of access methods that can be used to fetch the Data Object.
+          Required for single items; optional for bundles.
+      contents:
+        type: array
+        description: >-
+          If not set, this Object is a single item.
+          If set, this Object is a bundle containing the listed Objects (some of which may be further nested).
+        items:
+          $ref: '#/definitions/BundleObject'
       description:
         type: string
         description: |-
@@ -420,35 +332,26 @@ definitions:
       name:
         type: string
         description: >-
-          A name declared by the Bundle author that must be
+          A name declared by the bundle author that must be
           used when materialising the associated data object, 
           overriding any name directly associated with the object itself.
           This string MUST NOT contain any slashes.
       id:
         type: string
         description: >-
-          A DRS identifier of a Data Object or a nested Data Bundle.
+          A DRS identifier of a Data Object (either a single item or a nested bundle).
       drs_uri:
         type: array
         description: >-
           A list of full DRS identifier URI paths
-          that may be used obtain the Data Object or Data Bundle.
+          that may be used to obtain the Data Object.
           These URIs may be external to this DRS instance.
         example:
           drs://example.com/ga4gh/drs/v1/objects/{object_id}
         items:
           type: string
-      type:
-        type: string
-        enum:
-          - object
-          - bundle
-        description: >-
-          The type of content being referenced.
-          BundleObject of type bundle will need to be recursed further.
     required:
       - name
       - id
-      - type
 tags:
   - name: DataRepositoryService

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -198,7 +198,7 @@ definitions:
         minItems: 1
         items:
           $ref: '#/definitions/Checksum'
-        description: ]-
+        description: |-
           The checksum of the `Object`. At least one checksum must be provided.
           For blobs, the checksum is computed over the bytes in the blob.
           

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -212,22 +212,22 @@ definitions:
           
           For example, if a bundle contains blobs with the following checksums:
           
-          md5(blob1) = 72794b6d30bc86d92e40a1aa65c880b8
-            
-          md5(blob2) = 5e089d29a18954e68a78ee6a3c6edabd   
+          md5(blob1) = 72794b6d
+          
+          md5(blob2) = 5e089d29   
           
           
           Then the checksum of the bundle is:
           
           md5( concat( sort( md5(blob1), md5(blob2) ) ) )
-            
-          = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
-              
-          = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
-              
-          = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
-              
-          = f7a29a0422e7d870b10839ad6c985079
+          
+          = md5( concat( sort( 72794b6d, 5e089d29 ) ) )
+          
+          = md5( concat( 5e089d29, 72794b6d ) )
+          
+          = md5( 5e089d2972794b6d )
+          
+          = f7a29a04
       access_methods:
         type: array
         minItems: 1

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -212,21 +212,22 @@ definitions:
           
           For example, if a bundle contains blobs with the following checksums:
           
-            md5(blob1) = 72794b6d30bc86d92e40a1aa65c880b8
+          md5(blob1) = 72794b6d30bc86d92e40a1aa65c880b8
             
-            md5(blob2) = 5e089d29a18954e68a78ee6a3c6edabd   
-            
+          md5(blob2) = 5e089d29a18954e68a78ee6a3c6edabd   
+          
+          
           Then the checksum of the bundle is:
           
-            md5( concat( sort( md5(blob1), md5(blob2) ) ) )
+          md5( concat( sort( md5(blob1), md5(blob2) ) ) )
             
-              = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
+          = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
               
-              = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
+          = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
               
-              = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
+          = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
               
-              = f7a29a0422e7d870b10839ad6c985079
+          = f7a29a0422e7d870b10839ad6c985079
       access_methods:
         type: array
         minItems: 1

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -195,18 +195,18 @@ definitions:
           application/json
       checksums:
         type: array
-        minitems: 1
+        minItems: 1
         items:
           $ref: '#/definitions/Checksum'
         description: ]-
           The checksum of the `Object`. At least one checksum must be provided.
           For blobs, the checksum is computed over the bytes in the blob.
-
+          
           For bundles, the checksum is computed over a sorted concatenation of the 
           checksums of its top-level contained objects (not recursive, names not included).
           The list of checksums is sorted alphabetically (hex-code) before concatenation
           and a further checksum is performed on the concatenated checksum value.
-
+          
           For example, if a bundle contains blobs with the following checksums:
             md5(blob1) = 72794b6d30bc86d92e40a1aa65c880b8
             md5(blob2) = 5e089d29a18954e68a78ee6a3c6edabd       

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -169,7 +169,7 @@ definitions:
         format: int64
         description: |-
           For blobs, the blob size in bytes.
-          For bundles, the cumulative size, in bytes, of everything listed in the `contents` field.
+          For bundles, the cumulative size, in bytes, of items in the `contents` field.
       created:
         type: string
         format: date-time
@@ -183,8 +183,10 @@ definitions:
           that do not support updates.
       version:
         type: string
-        description: |-
+        description: >-
           A string representing a version.
+
+          (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)
       mime_type:
         type: string
         description: |-
@@ -193,31 +195,27 @@ definitions:
           application/json
       checksums:
         type: array
+        minItems: 1
         items:
           $ref: '#/definitions/Checksum'
-        description: >-
+        description: ]-
           The checksum of the `Object`. At least one checksum must be provided.
-
-
           For blobs, the checksum is computed over the bytes in the blob.
-          
-          For bundles, the checksum is computed over a sorted concatenation of all 
-          the checksums (names not included) of objects in the `contents` field
-          (not recursive). The list of checksums are
-          sorted alphabetically (hex-code) before concatenation and a further checksum
-          is performed on the concatenated checksum value.
-          Example below:
-          ```
-          Data Objects:
-            md5(DO1) = 72794b6d30bc86d92e40a1aa65c880b8
-            md5(DO2) = 5e089d29a18954e68a78ee6a3c6edabd       
-          Data Bundle:
-          DB1 = md5( concat( sort( md5(DO1), md5(DO2) ) ) )
+
+          For bundles, the checksum is computed over a sorted concatenation of the 
+          checksums of its top-level contained objects (not recursive, names not included).
+          The list of checksums is sorted alphabetically (hex-code) before concatenation
+          and a further checksum is performed on the concatenated checksum value.
+
+          For example, if a bundle contains blobs with the following checksums:
+            md5(blob1) = 72794b6d30bc86d92e40a1aa65c880b8
+            md5(blob2) = 5e089d29a18954e68a78ee6a3c6edabd       
+          Then the checksum of the bundle is:
+            md5( concat( sort( md5(blob1), md5(blob2) ) ) )
               = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
               = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
               = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
               = f7a29a0422e7d870b10839ad6c985079
-          ```
       access_methods:
         type: array
         minItems: 1
@@ -230,7 +228,8 @@ definitions:
         type: array
         description: >-
           If not set, this `Object` is a single blob.
-          If set, this `Object` is a bundle containing the listed Objects (some of which may be further nested).
+          
+          If set, this `Object` is a bundle containing the `BundleObject`s in the array (some of which may be further nested).
         items:
           $ref: '#/definitions/BundleObject'
       description:
@@ -244,7 +243,7 @@ definitions:
         description: >-
           A list of strings that can be used to find other metadata 
           about this `Object` from external metadata sources. These
-          aliases can be used to represent the `Object`'s secondary
+          aliases can be used to represent secondary
           accession numbers or external GUIDs.
   AccessURL:
     type: object

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -78,7 +78,7 @@ paths:
     get:
       summary: Get a URL for fetching bytes. 
       description: >-
-        Returns a URL that can be used to fetch the object bytes.
+        Returns a URL that can be used to fetch the bytes of an `Object`.
 
 
         This method only needs to be called when using an `AccessMethod` that contains an `access_id`
@@ -229,7 +229,7 @@ definitions:
         description: >-
           If not set, this `Object` is a single blob.
           
-          If set, this `Object` is a bundle containing the `BundleObject`s in the array (some of which may be further nested).
+          If set, this `Object` is a bundle containing the listed `BundleObject` s (some of which may be further nested).
         items:
           $ref: '#/definitions/BundleObject'
       description:

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -114,12 +114,12 @@ paths:
           in: path
           required: true
           type: string
-          description: An `id` of a Data Object
+          description: An `id` of an `Object`
         - name: access_id
           in: path
           required: true
           type: string
-          description: An `access_id` from the `access_methods` list of a Data Object
+          description: An `access_id` from the `access_methods` list of an `Object`
       tags:
         - DataRepositoryService
       x-swagger-router-controller: ga4gh.drs.server
@@ -195,7 +195,7 @@ definitions:
           application/json
       checksums:
         type: array
-        minItems: 1
+        minitems: 1
         items:
           $ref: '#/definitions/Checksum'
         description: ]-
@@ -336,18 +336,18 @@ definitions:
         type: string
         description: >-
           A name declared by the bundle author that must be
-          used when materialising the associated data object, 
+          used when materialising this object, 
           overriding any name directly associated with the object itself.
           This string MUST NOT contain any slashes.
       id:
         type: string
         description: >-
-          A DRS identifier of a Data Object (either a single item or a nested bundle).
+          A DRS identifier of an `Object` (either a single blob or a nested bundle).
       drs_uri:
         type: array
         description: >-
           A list of full DRS identifier URI paths
-          that may be used to obtain the Data Object.
+          that may be used to obtain the object.
           These URIs may be external to this DRS instance.
         example:
           drs://example.com/ga4gh/drs/v1/objects/{object_id}

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -37,13 +37,13 @@ paths:
       x-swagger-router-controller: ga4gh.drs.server
   '/objects/{object_id}':
     get:
-      summary: Get info about a Data Object.
+      summary: Get info about an `Object`.
       description: >-
         Returns object metadata, and a list of access methods that can be used to fetch object bytes.
       operationId: GetObject
       responses:
         '200':
-          description: The Data Object was found successfully.
+          description: The `Object` was found successfully.
           schema:
             $ref: '#/definitions/Object'
         '400':
@@ -59,7 +59,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
         '404':
-          description: The requested Data Object wasn't found
+          description: The requested `Object` wasn't found
           schema:
             $ref: '#/definitions/Error'
         '500':
@@ -159,16 +159,16 @@ definitions:
       id:
         type: string
         description: |-
-          An identifier unique to this Data Object.
+          An identifier unique to this `Object`.
       name:
         type: string
         description: |-
-          A string that can be used to name a Data Object.
+          A string that can be used to name an `Object`.
       size:
         type: integer
         format: int64
         description: |-
-          For single items, the object size in bytes.
+          For blobs, the blob size in bytes.
           For bundles, the cumulative size, in bytes, of everything listed in the `contents` field.
       created:
         type: string
@@ -179,7 +179,7 @@ definitions:
         type: string
         format: date-time
         description: >-
-          Timestamp of object update in RFC3339, identical to create timestamp in systems
+          Timestamp of `Object` update in RFC3339, identical to create timestamp in systems
           that do not support updates.
       version:
         type: string
@@ -188,59 +188,63 @@ definitions:
       mime_type:
         type: string
         description: |-
-          A string providing the mime-type of the Data Object.
+          A string providing the mime-type of the `Object`.
         example:
           application/json
       checksums:
         type: array
         items:
           $ref: '#/definitions/Checksum'
-        description: |-
-          The checksum of the Data Object. At least one checksum must be provided.
+        description: >-
+          The checksum of the `Object`. At least one checksum must be provided.
 
-          For single items, the checksum is computed over the bytes in the item.
+
+          For blobs, the checksum is computed over the bytes in the blob.
+          
           For bundles, the checksum is computed over a sorted concatenation of all 
-          the checksums (names not included) within the top-level `contents` field
+          the checksums (names not included) of objects in the `contents` field
           (not recursive). The list of checksums are
           sorted alphabetically (hex-code) before concatenation and a further checksum
           is performed on the concatenated checksum value.
           Example below:
+          ```
           Data Objects:
             md5(DO1) = 72794b6d30bc86d92e40a1aa65c880b8
-            md5(DO2) = 5e089d29a18954e68a78ee6a3c6edabd
+            md5(DO2) = 5e089d29a18954e68a78ee6a3c6edabd       
           Data Bundle:
           DB1 = md5( concat( sort( md5(DO1), md5(DO2) ) ) )
               = md5( concat( sort( 72794b6d30bc86d92e40a1aa65c880b8, 5e089d29a18954e68a78ee6a3c6edabd ) ) )
               = md5( concat( 5e089d29a18954e68a78ee6a3c6edabd, 72794b6d30bc86d92e40a1aa65c880b8 ) )
               = md5( 5e089d29a18954e68a78ee6a3c6edabd72794b6d30bc86d92e40a1aa65c880b8 )
               = f7a29a0422e7d870b10839ad6c985079
+          ```
       access_methods:
         type: array
         minItems: 1
         items:
           $ref: '#/definitions/AccessMethod'
         description: |-
-          The list of access methods that can be used to fetch the Data Object.
-          Required for single items; optional for bundles.
+          The list of access methods that can be used to fetch the `Object`.
+          Required for single blobs; optional for bundles.
       contents:
         type: array
         description: >-
-          If not set, this Object is a single item.
-          If set, this Object is a bundle containing the listed Objects (some of which may be further nested).
+          If not set, this `Object` is a single blob.
+          If set, this `Object` is a bundle containing the listed Objects (some of which may be further nested).
         items:
           $ref: '#/definitions/BundleObject'
       description:
         type: string
         description: |-
-          A human readable description of the Data Object.
+          A human readable description of the `Object`.
       aliases:
         type: array
         items:
           type: string
         description: >-
           A list of strings that can be used to find other metadata 
-          about this Data Object from external metadata sources. These
-          aliases can be used to represent the Data Object's secondary
+          about this `Object` from external metadata sources. These
+          aliases can be used to represent the `Object`'s secondary
           accession numbers or external GUIDs.
   AccessURL:
     type: object


### PR DESCRIPTION
Changes, as discussed in https://github.com/ga4gh/data-repository-service-schemas/issues/252#issuecomment-487535043: 
- make Object.access_methods optional (but document that it's required for Objects)
- add an optional Object.contents field (but document that it's required for Bundles)
- delete the Bundle object and the /bundles method

Still needs work on documentation, to consistently refer to objects, blobs, and bundles.
