### PR TITLE
Enable handling of data access delays using HTTP 301/Retry-After

### DIFF
--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -46,14 +46,15 @@ paths:
           description: The `Object` was found successfully.
           schema:
             $ref: '#/definitions/Object'
-        '301':
+        '202':
           description: >
             The operation is delayed and will continue asynchronously.
-            The client should follow the redirect after the delay specified in the Retry-After header.
+            The client should retry this same request after the delay specified by Retry-After header.
           headers:
             Retry-After:
               description: >
-                Delay in seconds. The client should follow the redirect after waiting for this duration.
+                Delay in seconds. The client should retry this same request after waiting for this duration.
+                To simplify client response processing, this must be an integral relative time in seconds.
                 This value SHOULD represent the minimum duration the client should wait before attempting
                 the operation again with a reasonable expectation of success. When it is not feasible
                 for the server to determine the actual expected delay, the server may return a
@@ -103,14 +104,15 @@ paths:
           description: The access URL was found successfully.
           schema:
             $ref: '#/definitions/AccessURL'
-        '301':
+        '202':
           description: >
             The operation is delayed and will continue asynchronously.
-            The client should follow the redirect after the delay specified in the Retry-After header.
+            The client should retry this same request after the delay specified by Retry-After header.
           headers:
             Retry-After:
               description: >
-                Delay in seconds. The client should follow the redirect after waiting for this duration.
+                Delay in seconds. The client should retry this same request after waiting for this duration.
+                To simplify client response processing, this must be an integral relative time in seconds.
                 This value SHOULD represent the minimum duration the client should wait before attempting
                 the operation again with a reasonable expectation of success. When it is not feasible
                 for the server to determine the actual expected delay, the server may return a

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -46,6 +46,20 @@ paths:
           description: The `Object` was found successfully.
           schema:
             $ref: '#/definitions/Object'
+        '301':
+          description: >
+            The operation is delayed and will continue asynchronously.
+            The client should follow the redirect after the delay specified in the Retry-After header.
+          headers:
+            Retry-After:
+              description: >
+                Delay in seconds. The client should follow the redirect after waiting for this duration.
+                This value SHOULD represent the minimum duration the client should wait before attempting
+                the operation again with a reasonable expectation of success. When it is not feasible
+                for the server to determine the actual expected delay, the server may return a
+                brief, fixed value instead.
+              type: integer
+              format: int64
         '400':
           description: The request is malformed.
           schema:
@@ -89,6 +103,20 @@ paths:
           description: The access URL was found successfully.
           schema:
             $ref: '#/definitions/AccessURL'
+        '301':
+          description: >
+            The operation is delayed and will continue asynchronously.
+            The client should follow the redirect after the delay specified in the Retry-After header.
+          headers:
+            Retry-After:
+              description: >
+                Delay in seconds. The client should follow the redirect after waiting for this duration.
+                This value SHOULD represent the minimum duration the client should wait before attempting
+                the operation again with a reasonable expectation of success. When it is not feasible
+                for the server to determine the actual expected delay, the server may return a
+                brief, fixed value instead.
+              type: integer
+              format: int64
         '400':
           description: The request is malformed.
           schema:


### PR DESCRIPTION
### Motivation
There are cases in which storage systems incur data access delays longer than a reasonable HTTP request timeout, and the DRS specification must include provision for handling this.
The causes of these delays may include access to data in cold storage, system-specific internal data transfers, system load, and occasional aberrant delays in the system or underlying cloud platform.

For DRS to be a robust and broadly applicable standard, it must provide a way for the client and server to negotiate through data access delays.
Because DRS is intended for use with genomic data, genomic datasets tend to be large and long-lived, and storage costs must be minimized/managed, the ability to support cold storage is essential.
Although some major cold storage systems provide low latency access to data in cold storage, others do not.

To focus on a concrete example, consider the use of DRS for a genomic data storage system utilizing _AWS Glacier_ for cold storage.  The [AWS product page for _Glacier_](https://aws.amazon.com/glacier/) defines Glacier's data access latency as follows:

> Expedited retrievals typically return data in 1-5 minutes, and are great for Active Archive use cases. Standard retrievals typically complete between 3-5 hours work, and work well for less time-sensitive needs like backup data, media editing, or long-term analytics. Bulk retrievals are the lowest-cost retrieval option, returning large amounts of data within 5-12 hours.

Moreover, consider the case of the storage system service running on AWS infrastructure utilizing the _AWS API Gateway_, which has a fixed HTTP request timeout value of 30 seconds. Because data access requiring minutes (or hours) cannot be completed within the 30-second timeout, there must be an interactive collaboration between the client and server to complete the data access operation.

DRS must be applicable to genomic data repository services that support a major cloud vendor using the vendor's current services for cost-effective storage of large data sets. Doing so requires that the client and server be able to negotiate through potentially long data access delays.

### Design

The proposed design is based on standard HTTP semantics defined in [RFC 7321](https://tools.ietf.org/html/rfc7231). In short, if a data access operation is going to take more time than can be reasonably accommodated by a single HTTP request, the operation may return a response with HTTP code 301 (Moved Permanently) with a `Retry-After` header.

* [HTTP Code 301 (Moved Permanently)](https://tools.ietf.org/html/rfc7231#section-6.4.2):
If/when a data repository service incurs a delay longer than a reasonable HTTP timeout, it should respond with HTTP code 301 and include the HTTP header `Retry-After`. After waiting for the specified `Retry-After` duration, the client is should redirect to the URL provided in the `Location` header.

* [HTTP Header `Retry-After`](https://tools.ietf.org/html/rfc7231#section-7.1.3)
The `Retry-After` value SHOULD represent the minimum duration the client should wait before attempting the operation again with a reasonable expectation of success.
However, it may not be feasible for a DRS service to accurately identify the expected duration, depending on the operation, underlying cloud storage service, etc. Therefore, it is permissible to return a relatively short, fixed duration (e.g. 10 seconds) and repeat this interaction as needed until such time as the data access operation is complete. 

This optional 301 response with a `Retry-After` header is defined for all DRS operations involving stored data access. Although some DRS operations (e.g. `/objects/{object_id}/access/{access_id}`) may be more likely to encounter a data access delay than others (e.g. `/bundles/{bundle_id}`), it is not possible to identify which data access operations may or may not encounter delays in all current and future storage systems. It seems better to define a simple mechanism broadly across all data access operations than to add it for a subset of operations now and incrementally add support for more as needed over time, requiring additional and otherwise unnecessary DRS specification revisions.

### Implementation and Use Considerations
The impact of data access delays on workflow execution services and other large-scale analyses warrants special consideration. Data access delays occurring during execution can be very costly and time-consuming, especially when multiplied by thousands of files and a large scale execution infrastructure is already spun-up.

Any viable data repository service providing data for analysis purposes must provide a way to mitigate/minimize data access delays during workflow execution.
One effective technique is for the service to use a long-lived data cache. For example, although the delay of retrieving a given file from cold storage may be unavoidable, the service may place the file in a long-lived cache so that subsequent access to the file is fast.

The presence of a long-lived cache enables workflow orchestration services to perform an initial DRS data access operation for all input data before spinning-up the execution infrastructure, thus incurring the delays less expensively and ensuring the actual workflow execution data access is fast.

### Notes

This PR is submitted on behalf of the Human Cell Atlas (HCA) driver project.

The [HCA data-store](https://github.com/HumanCellAtlas/data-store) is designed to store large volumes of genomic sequencing, imaging, and other data for researchers worldwide. It replicates the data across major cloud platforms (currently AWS and GCP) to allow researchers to use the cloud platform of their choice for workflow execution and analysis.

The use of SHOULD is as defined in [RFC 2119](https://tools.ietf.org/html/rfc2119).

Resolves #238