### PR TITLE
Update the service-info to use the ga4gh discovery standard in progress (resolves #264)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
 - '2.7'

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -322,25 +322,30 @@ definitions:
   ServiceInfo:
     type: object
     required:
+      - id
+      - name
       - version
     description: >-
       Useful information about the running service.
     properties:
-      version:
+      id:
         type: string
-        description: Service version
-      title:
+        description: Unique ID of this service. Reverse domain name notation is recommended, though not required.  
+      name:
         type: string
-        description: Service name
+        description: Name of this specific service.
       description:
         type: string
-        description: Service description
-      contact:
-        type: object
-        description: Maintainer contact info
-      license:
-        type: object
-        description: License information for the exposed API
+        description: Description of the service.
+      documentationUrl:
+        type: string
+        description: URL of the documentation of this service (RFC 3986 format).
+      contactUrl:
+        type: string
+        description: 'URL of the contact for the host/maintainer of this service, e.g. a link to a contact form (RFC 3986 format), or an email (RFC 2368 format).'
+      version:
+        type: string
+        description: Version of the service.
   ContentsObject:
     type: object
     properties:


### PR DESCRIPTION
See the issue #264 

This PR is trying to harmonize the service-info endpoint to [service-info format being proposed for all of GA4GH](https://github.com/ga4gh-discovery/ga4gh-service-info).  This is still a work in progress and hasn't been approved yet.

Some potential problems, I think we ultimately need a service-info endpoint of service-info endpoints.  Something like:

https://drs-server.com/service-info

And that should respond with something like:

```
[ https://drs-server.com/ga4g/drs/v1/service-info,
https://drs-server.com/ga4g/drs/v2/service-info ]
```

In this way you could discover very clearly what are the available versions of DRS on this server and how to make requests for them.

Another point, right now there is no concept of API type.  This could (should) be a CV term where we uniquely identify the API supported by this endpoint e.g. [wes, trs, drs, tes, etc]

Compared to our original service-info endpoint, I removed the following:

-title
-contact
-license

Otherwise the [service-info endpoint proposal](https://github.com/ga4gh-discovery/ga4gh-service-info/blob/develop/service-info.yaml) is almost identical to what we had already.