### PR TITLE
Add expand query parameter and recursive bundle representation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
 - '2.7'

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -71,6 +71,22 @@ paths:
           in: path
           required: true
           type: string
+        - in: query
+          name: expand
+          type: boolean
+          default: false
+          description: >-
+            If false and the object_id refers to a bundle, then the ObjectContents array
+            contains only those objects directly contained in the bundle. That is, if the
+            bundle contains other bundles, those other bundles are not recursively
+            included in the result.
+            
+            If true and the object_id refers to a bundle, then the entire set of objects
+            in the bundle is expanded. That is, if the bundle contains aother bundles,
+            then those other bundles are recursively expanded and included in the result.
+            Recursion continues through the entire sub-tree of the bundle.
+
+            If the object_id refers to a blob, then the query parameter is ignored.
       tags:
         - DataRepositoryService
       x-swagger-router-controller: ga4gh.drs.server
@@ -361,10 +377,22 @@ definitions:
           A list of full DRS identifier URI paths
           that may be used to obtain the object.
           These URIs may be external to this DRS instance.
+
+          If this ContentsObject describes a nested bundle, the drs_uri array may be
+          empty. A DRS server need not provide an object id or DRS URI for a nested bundle.
         example:
           drs://example.com/ga4gh/drs/v1/objects/{object_id}
         items:
           type: string
+      contents:
+        type: array
+        description: >-
+          If this ObjectContents describes a nested bundle and the caller specified
+          "?expand=true" on the request, then this contents array must be present and
+          describe the objects within the nested bundle.
+        items:
+          $ref: '#/definitions/ContentsObject'
+        
     required:
       - name
       - id

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -76,7 +76,7 @@ paths:
           type: boolean
           default: false
           description: >-
-            If false and the object_id refers to a bundle, then the ObjectsContent array
+            If false and the object_id refers to a bundle, then the ContentsObject array
             contains only those objects directly contained in the bundle. That is, if the
             bundle contains other bundles, those other bundles are not recursively
             included in the result.

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -76,7 +76,7 @@ paths:
           type: boolean
           default: false
           description: >-
-            If false and the object_id refers to a bundle, then the ObjectContents array
+            If false and the object_id refers to a bundle, then the ObjectsContent array
             contains only those objects directly contained in the bundle. That is, if the
             bundle contains other bundles, those other bundles are not recursively
             included in the result.
@@ -371,15 +371,14 @@ definitions:
         type: string
         description: >-
           A DRS identifier of an `Object` (either a single blob or a nested bundle).
+          If this ContentsObject is an object within a nested bundle, then the id is
+          optional. Otherwise, the id is required.
       drs_uri:
         type: array
         description: >-
           A list of full DRS identifier URI paths
           that may be used to obtain the object.
           These URIs may be external to this DRS instance.
-
-          If this ContentsObject describes a nested bundle, the drs_uri array may be
-          empty. A DRS server need not provide an object id or DRS URI for a nested bundle.
         example:
           drs://example.com/ga4gh/drs/v1/objects/{object_id}
         items:
@@ -395,6 +394,5 @@ definitions:
         
     required:
       - name
-      - id
 tags:
   - name: DataRepositoryService

--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -386,7 +386,7 @@ definitions:
       contents:
         type: array
         description: >-
-          If this ObjectContents describes a nested bundle and the caller specified
+          If this ContentsObject describes a nested bundle and the caller specified
           "?expand=true" on the request, then this contents array must be present and
           describe the objects within the nested bundle.
         items:


### PR DESCRIPTION
As discussed in our meeting of June 10, this PR adds two things:
1. A `expand` query flag on the `GET /object/{object_id}` endpoint to request a full, recursive expansion of all nested bundles, if the object is a bundle.
2. A `contents` field in the `ContentsObject` to represent the contents of the nested bundle.

I included the semantic that a server is not required to provide object ids or DRS URIs for nested bundles.
