### PR TITLE
Add self property drs object

### DIFF
--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -217,6 +217,12 @@ definitions:
         description: |-
           For blobs, the blob size in bytes.
           For bundles, the cumulative size, in bytes, of items in the `contents` field.
+      self:
+        type: string
+        description: |-
+          A DRS URI referencing where this `Object` was retrieved from.
+        example:
+          drs://example.com/ga4gh/drs/v1/objects/{id}
       created:
         type: string
         format: date-time


### PR DESCRIPTION
## Problem
I am in the process of creating a number of  POC services which consume a `DRS` URI (using the develop schema) as input in order to demonstrate the capabilities of `DRS`. Throughout this process I have come across a few situations where I am left with a `DRS` object but have lost the initial context from which it was retrieved from. The technical reason why I have encountered this issue is due to the separation of concerns. The component which retrieves the `DRS` object is separate then the one which actually does some down stream processing of it. 

In most situations, not knowning where the object came from is fine. However If ever I need to hit the `objects/{id}/access/{access_id}`, I am unable to resolve the appropriate path to retrieve the `access_url`. I do believe there will be many other scenarios for consumers of `DRS` where an `object` becomes detached from the context which it was retrieved, rendering any additional API calls impossible.

## Proposal
Fundamentally, I believe a `DRS` object should be self describing, including where the object came from.   I propose the inclusion of a single `self` property within the `Object`. The property should be a `DRS` `URI` which refers to the exact location which produced said object.

Ideally, this property would be required, however I understand there may be some scenarios where there is no `self` and the `DRS` object is just a wrapper to convey information on an object.