### PR TITLE
Clarify uniqueness of access_id

### DIFF
--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -347,7 +347,7 @@ definitions:
         type: string
         description: >-
           An arbitrary string to be passed to the `/access` method to get an `AccessURL`.
-          This string must be unique per object.
+          This string must be unique within the scope of a single object.
           Note that at least one of `access_url` and `access_id` must be provided.
       region:
         type: string


### PR DESCRIPTION
Addresses [DRS v1 PRC #7 - Make the uniqueness of the access_id optional](https://docs.google.com/document/d/1gCTFFomdUhP7dPJD6H-eqQ77OmLszvKGDqJXaBkU9SU/edit#heading=h.hjuct0b5v60)