### PR TITLE
Doc updates DRS v1 SecReview comments

### DIFF
--- a/docs/asciidoc/front_matter.adoc
+++ b/docs/asciidoc/front_matter.adoc
@@ -41,7 +41,7 @@ The DRS API specification is written in OpenAPI and embodies a RESTful service p
 
 === Making DRS Requests
 
-The DRS implementation is responsible for defining and enforcing an authorization policy that determines which users are allowed to make which requests. We recommend that DRS implementations use an OAuth2 https://oauth.net/2/bearer-tokens/[bearer token], although they can choose other mechanisms if appropriate.  The `service-info` endpoint should provide sufficient information for a user to figure out how to authenticate with a DRS implementation.
+The DRS implementation is responsible for defining and enforcing an authorization policy that determines which users are allowed to make which requests. GA4GH recommends that DRS implementations use an OAuth 2.0 https://oauth.net/2/bearer-tokens/[bearer token], although they can choose other mechanisms if appropriate.  The `service-info` endpoint should provide sufficient information for a user to figure out how to authenticate with a DRS implementation.
 
 === Fetching DRS Objects
 
@@ -61,3 +61,5 @@ The DRS API allows implementers to support a variety of different content access
 ** caller passes the `access_id` to the `/access` endpoint
 ** server provides an `access_url` with the generated mechanism (e.g. a signed URL in the `url` field)
 ** caller fetches the object bytes from the `url` (passing auth info from the specified headers, if any)
+
+DRS implementers should ensure their solutions restrict access to targets as much as possible, detect attempts to exploit through log monitoring, and they are prepared to take action if an exploit in their DRS implementation is detected.


### PR DESCRIPTION
Doc updates to address [DRS v1 SecReview](https://docs.google.com/document/d/1MaV8GX0xLLq3jZ8BGHGLEkY5rlHwWopyHOWEkV5NeiE/edit#) comments.

Duplicate of PR #288 but correctly targetting [drs-1.0.0 release](https://github.com/ga4gh/data-repository-service-schemas/tree/release/drs-1.0.0)