### PR TITLE
Update DRS documentation to remove service-info

### DIFF
--- a/docs/asciidoc/front_matter.adoc
+++ b/docs/asciidoc/front_matter.adoc
@@ -41,7 +41,7 @@ The DRS API specification is written in OpenAPI and embodies a RESTful service p
 
 === Making DRS Requests
 
-The DRS implementation is responsible for defining and enforcing an authorization policy that determines which users are allowed to make which requests. GA4GH recommends that DRS implementations use an OAuth 2.0 https://oauth.net/2/bearer-tokens/[bearer token], although they can choose other mechanisms if appropriate.  The `service-info` endpoint should provide sufficient information for a user to figure out how to authenticate with a DRS implementation.
+The DRS implementation is responsible for defining and enforcing an authorization policy that determines which users are allowed to make which requests. GA4GH recommends that DRS implementations use an OAuth 2.0 https://oauth.net/2/bearer-tokens/[bearer token], although they can choose other mechanisms if appropriate. 
 
 === Fetching DRS Objects
 


### PR DESCRIPTION
- [x] Remove mentions of `/service-info` from front_matter.adoc
- [x] Check if there are other mentions in back_matter.adoc
- [x] Check if there are any other remenants other doc files

resolves: #291 