### PR TITLE
Fix incorrect DRS URI example

### DIFF
--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -388,7 +388,7 @@ definitions:
           that may be used to obtain the object.
           These URIs may be external to this DRS instance.
         example:
-          drs://example.com/ga4gh/drs/v1/objects/{object_id}
+          drs://drs.example.org/314159
         items:
           type: string
       contents:


### PR DESCRIPTION
See [Issue 296](https://github.com/ga4gh/data-repository-service-schemas/issues/296) for a description of the problem.

Simple PR to correct a misleading example.
