### PR TITLE
Add dicomweb to AccessMethod types

### DIFF
--- a/openapi/data_repository_service.swagger.yaml
+++ b/openapi/data_repository_service.swagger.yaml
@@ -334,6 +334,7 @@ definitions:
         - htsget
         - https
         - file
+        - dicomweb
         description: >-
           Type of the access method.
       access_url:


### PR DESCRIPTION
Added 'dicomweb' to AccessMethod types in support of DICOM files stored in a [DICOMweb](https://www.dicomstandard.org/dicomweb) capable server.