### PR TITLE
deprecating bundles (documentation changes only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more information see our HTML documentation links in the table below.
 | **release 0.1**: Simplifying DRS to core functionality | [HTML](https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-0.1.0/docs/) | [Swagger Editor](https://editor.swagger.io?url=https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-0.1.0/swagger.yaml) |
 | **release 0.0.1**: The initial DRS after the rename from DOS | [HTML](https://ga4gh.github.io/data-repository-service-schemas/preview/release/0.0.1/docs/) | [Swagger Editor](https://editor.swagger.io?url=https://ga4gh.github.io/data-repository-service-schemas/preview/release/0.0.1/swagger.yaml) |
 
-To monitor development work on various branches, add 'preview/\<branch-name\>' to the master URLs above (e.g., 'https://ga4gh.github.io/data-repository-service-schemas/preview/\<branch-name\>/docs').
+To monitor development work on various branches, add 'preview/\<branch-name\>' to the master URLs above (e.g., `https://ga4gh.github.io/data-repository-service-schemas/preview/<branch-name>/docs`).
 
 # How to Contribute Changes
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <img src="https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg" alt="GA4GH Logo" style="width: 400px;"/>
 
+<<Branch for David G to add language about deprecation of bundles>>
+
 # Data Repository Service (DRS) API
 
 <sup>`develop` branch status: </sup>[![Build Status](https://travis-ci.org/ga4gh/data-repository-service-schemas.svg?branch=develop)](https://travis-ci.org/ga4gh/data-repository-service-schemas?branch=develop)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <img src="https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg" alt="GA4GH Logo" style="width: 400px;"/>
 
-<<Branch for David G to add language about deprecation of bundles>>
-
 # Data Repository Service (DRS) API
 
 <sup>`develop` branch status: </sup>[![Build Status](https://travis-ci.org/ga4gh/data-repository-service-schemas.svg?branch=develop)](https://travis-ci.org/ga4gh/data-repository-service-schemas?branch=develop)

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -105,7 +105,7 @@ x-tagGroups:
   - name: Appendices
     tags:
       - Motivation
-      - Compound Objects
+      - Best Practices for Working with Compund Objects
       - Background Notes on DRS URIs
       - Compact Identifier-Based URIs
       - Hostname-Based URIs

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -69,7 +69,7 @@ tags:
   - name: Motivation
     description:
       $ref: './tags/Motivation.md'
-  - name: Best Practices for Working with Compund Objects
+  - name: Working with Compound Objects
     description:
       $ref: './tags/CompoundObjects.md'
   - name: Background Notes on DRS URIs
@@ -105,7 +105,7 @@ x-tagGroups:
   - name: Appendices
     tags:
       - Motivation
-      - Best Practices for Working with Compund Objects
+      - Working with Compound Objects
       - Background Notes on DRS URIs
       - Compact Identifier-Based URIs
       - Hostname-Based URIs

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -69,6 +69,9 @@ tags:
   - name: Motivation
     description:
       $ref: './tags/Motivation.md'
+  - name: Best Practices for Working with Compund Objects
+    description:
+      $ref: './tags/CompoundObjects.md'
   - name: Background Notes on DRS URIs
     description:
       $ref: './tags/BackgroundNotesOnDRSURIs.md'

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -69,7 +69,7 @@ tags:
   - name: Motivation
     description:
       $ref: './tags/Motivation.md'
-  - name: Working with Compound Objects
+  - name: Working With Compound Objects
     description:
       $ref: './tags/CompoundObjects.md'
   - name: Background Notes on DRS URIs
@@ -105,7 +105,7 @@ x-tagGroups:
   - name: Appendices
     tags:
       - Motivation
-      - Working with Compound Objects
+      - Working With Compound Objects
       - Background Notes on DRS URIs
       - Compact Identifier-Based URIs
       - Hostname-Based URIs

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -105,6 +105,7 @@ x-tagGroups:
   - name: Appendices
     tags:
       - Motivation
+      - Compound Objects
       - Background Notes on DRS URIs
       - Compact Identifier-Based URIs
       - Hostname-Based URIs

--- a/openapi/tags/CompoundObjects.md
+++ b/openapi/tags/CompoundObjects.md
@@ -1,11 +1,13 @@
 ## Compound Objects
 
+The DRS API supports access to data objects, with each `DrsObject` representing a single opaque blob of bytes. Much content (e.g. VCF files) is well represented as a single `DrsObject`. Some content, however (e.g. DICOM images) is best represented as a compound object consisting of a structured collection of 'leaf' `DrsObject`s. In both cases, DRS isn't aware of the semantics of the objects it serves -- understanding those semantics is the responsibility of the applications that call DRS.
+
 Common examples of compound objects in biomedicine include:
 * BAM+BAI genomic reads, with a small index (the BAI object) to large data (the BAM object), each object using a well-defined file format.
 * DICOM images, with a contents object pointing to one or more raw image objects, each containing pixels from different aspects of a single logical biomedical image (e.g. different z-coordinates)
 * studies, with a single table of contents listing multiple objects of various types that were generated together and are meant to be processed together
 
-As with single objects, DRS clients and servers are expected to agree on the semantics of individual compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
-1. Define a manifest file syntax, which contains a list of the DRS IDs of the leaf objects, plus type-specific information about the relationship between the different elements of the compound object.
-2. Make manifest objects, and each of their referenced leaf objects, available using standard DRS mechanisms -- each manifest and each leaf are referenced via their own DRS IDs, just like any other single object.
+As with single objects, DRS applications and servers are expected to agree on the semantics of individual compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
+1. Define a manifest file syntax, which contains a list of the DRS IDs of the leaf objects, plus type-specific information about the relationship between the different elements of the compound object. Manifest file syntax isn't prescribed by the spec, but we expect they will often be JSON files.
+2. Make manifest objects, and each of their referenced leaf objects, available using standard DRS mechanisms -- each manifest object and each leaf object are referenced via their own DRS IDs, just like any other single object.
 3. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of leaf objects, and using standard DRS mechanisms to fetch relevant leaf objects.

--- a/openapi/tags/CompoundObjects.md
+++ b/openapi/tags/CompoundObjects.md
@@ -1,0 +1,1 @@
+TODO: insert best practices here

--- a/openapi/tags/CompoundObjects.md
+++ b/openapi/tags/CompoundObjects.md
@@ -1,1 +1,11 @@
-TODO: insert best practices here
+## Compound Objects
+
+Common examples of compound objects in biomedicine include:
+* BAM+BAI genomic reads, with a small index (the BAI object) to large data (the BAM object), each object using a well-defined file format.
+* DICOM images, with a contents object pointing to one or more raw image objects, each containing pixels from different aspects of a single logical biomedical image (e.g. different z-coordinates)
+* studies, with a single table of contents listing multiple objects of various types that were generated together and are meant to be processed together
+
+As with single objects, DRS clients and servers are expected to agree on the semantics of individual compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
+1. Define a manifest file syntax, which contains a list of the DRS IDs of the leaf objects, plus type-specific information about the relationship between the different elements of the compound object.
+2. Make manifest objects, and each of their referenced leaf objects, available using standard DRS mechanisms -- each manifest and each leaf are referenced via their own DRS IDs, just like any other single object.
+3. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of leaf objects, and using standard DRS mechanisms to fetch relevant leaf objects.

--- a/openapi/tags/CompoundObjects.md
+++ b/openapi/tags/CompoundObjects.md
@@ -1,13 +1,19 @@
 ## Compound Objects
 
-The DRS API supports access to data objects, with each `DrsObject` representing a single opaque blob of bytes. Much content (e.g. VCF files) is well represented as a single `DrsObject`. Some content, however (e.g. DICOM images) is best represented as a compound object consisting of a structured collection of 'leaf' `DrsObject`s. In both cases, DRS isn't aware of the semantics of the objects it serves -- understanding those semantics is the responsibility of the applications that call DRS.
+The DRS API supports access to data objects, with each `DrsObject` representing a single opaque blob of bytes. Much content (e.g. VCF files) is well represented as a single atomic `DrsObject`. Some content, however (e.g. DICOM images) is best represented as a compound object consisting of a structured collection of atomic `DrsObject`s. In both cases, DRS isn't aware of the semantics of the objects it serves -- understanding those semantics is the responsibility of the applications that call DRS.
 
 Common examples of compound objects in biomedicine include:
 * BAM+BAI genomic reads, with a small index (the BAI object) to large data (the BAM object), each object using a well-defined file format.
 * DICOM images, with a contents object pointing to one or more raw image objects, each containing pixels from different aspects of a single logical biomedical image (e.g. different z-coordinates)
 * studies, with a single table of contents listing multiple objects of various types that were generated together and are meant to be processed together
 
-As with single objects, DRS applications and servers are expected to agree on the semantics of individual compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
-1. Define a manifest file syntax, which contains a list of the DRS IDs of the leaf objects, plus type-specific information about the relationship between the different elements of the compound object. Manifest file syntax isn't prescribed by the spec, but we expect they will often be JSON files.
-2. Make manifest objects, and each of their referenced leaf objects, available using standard DRS mechanisms -- each manifest object and each leaf object are referenced via their own DRS IDs, just like any other single object.
-3. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of leaf objects, and using standard DRS mechanisms to fetch relevant leaf objects.
+## Best Practice: Manifests
+
+As with atomic objects, DRS applications and servers are expected to agree on the semantics of compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
+1. Define a manifest file syntax, which contains the DRS IDs of the constituent atomic objects, plus type-specific information about the relationship between those constituents.
+    * Manifest file syntax isn't prescribed by the spec, but we expect they will often be JSON files.
+    * For example, for a BAM+BAI pair the manifest file could contain two key-value pairs mapping the type of each constituent file to its DRS ID.
+3. Make manifest objects and their constituent objects available using standard DRS mechanisms -- each object is referenced via its own DRS ID, just like any other atomic object.
+    * For example, for a BAM+BAI pair, there would be three DRS IDs -- one for the manifest, one for the BAM, and one for the BAI.
+5. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of constituent objects, and using standard DRS mechanisms to fetch the constituents as needed.
+    * In some cases the application will always want to fetch all of the constituents; in other cases it may want to initially fetch a subset, and only fetch the others on demand. For example, a DICOM image viewer may only want to fetch the layers that are being rendered.

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -110,10 +110,10 @@ DRS's job is data access, period. Therefore, the DRS API supports a simple flat 
 DRS can be used to access individual objects of all kinds, simple or complex, large or small, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on object semantics using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
-DRS can also be used to access compound objects, consisting of two or more atomic objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Compound-Objects) for suggested best practices for working with Compound Objects. 
+DRS can also be used to access compound objects, consisting of two or more atomic objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects) for suggested best practices for working with Compound Objects. 
 
 ### [DEPRECATED] Bundles
-Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the best practices documented in the [Appendix: Compound Objects](#tag/Compound-Objects). A future version of the API spec may remove bundle support entirely.
+Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the best practices documented in the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects). A future version of the API spec may remove bundle support entirely.
 
 ## Read-only
 

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -110,10 +110,10 @@ DRS's job is data access, period. Therefore, the DRS API supports a simple flat 
 DRS can be used to access individual objects of all kinds, simple or complex, large or small, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on object semantics using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
-DRS can also be used to access compound objects, consisting of two or more atomic objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects) for suggested best practices for working with compound objects. 
+DRS can also be used to access compound objects, consisting of two or more atomic objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects) for suggested best practices for working with compound objects.
 
 ### [DEPRECATED] Bundles
-Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the best practices documented in the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects). A future version of the API spec may remove bundle support entirely.
+Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the best practices documented in the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects). A future version of the API spec may remove bundle support entirely and/or replace bundles with a scalable approach based on the needs of our driver projects.
 
 ## Read-only
 

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -99,7 +99,7 @@ DRS servers can choose to issue either hostname-based or compact identifier-base
 
 |                   | Hostname-based | Compact Identifier-based |
 |-------------------|----------------|--------------------------|
-| UR \I Durability    | URIs are valid for as long as the server operator maintains ownership of the published DNS address. (They can of course point that address at different physical serving infrastructure as often as they would like.) | URIs are valid for as long as the server operator maintains ownership of the published compact identifier resolver namespace. (They also depend on the meta-resolvers like identifiers.org/n2t.net remaining operational, which is intended to be essentially forever.) |
+| URI Durability    | URIs are valid for as long as the server operator maintains ownership of the published DNS address. (They can of course point that address at different physical serving infrastructure as often as they would like.) | URIs are valid for as long as the server operator maintains ownership of the published compact identifier resolver namespace. (They also depend on the meta-resolvers like identifiers.org/n2t.net remaining operational, which is intended to be essentially forever.) |
 | Client Efficiency | URIs require minimal client logic, and no network requests, to resolve. | URIs require small client logic, and 1-2 cacheable network requests, to resolve. |
 | Security          | Servers have full control over their own security practices. | Server operators, in addition to maintaining their own security practices, should confirm they are comfortable with the resolver registry security practices, including protection against denial of service and namespace-hijacking attacks. (See the [Appendix: Compact Identifier-Based URIs](#tag/Compact-Identifier-Based-URIs) for more information on resolver registry security.) |
 
@@ -121,7 +121,7 @@ As with simple objects, DRS clients and servers are expected to agree on the sem
 3. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of leaf objects, and using standard DRS mechanisms to fetch relevant leaf objects.
 
 ### [DEPRECATED] Bundles
-Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.*TODO*, bundles have been deprecated in favor of the Compound Object best practice documented above. A future version of the API spec may remove bundle support entirely.
+Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the Compound Object best practice documented above. A future version of the API spec may remove bundle support entirely.
 
 ## Read-only
 

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -104,7 +104,7 @@ DRS servers can choose to issue either hostname-based or compact identifier-base
 | Security          | Servers have full control over their own security practices. | Server operators, in addition to maintaining their own security practices, should confirm they are comfortable with the resolver registry security practices, including protection against denial of service and namespace-hijacking attacks. (See the [Appendix: Compact Identifier-Based URIs](#tag/Compact-Identifier-Based-URIs) for more information on resolver registry security.) |
 
 ## DRS Datatypes
-DRS's job is data acccess, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject` represents a single opaque blob of bytes, which (like a file) has no inherent semantic meeting and only simple domain-agnostic metadata. Data organization, discovery, and understanding are left to higher levels of the stack.
+DRS's job is data acccess, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject` represents a single opaque blob of bytes, which (like a file) has no inherent semantic meaning and only simple domain-agnostic metadata. Data organization, discovery, and understanding are left to higher levels of the stack.
 
 ### Simple Objects
 DRS can be used to access objects of all kinds, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechansisms, including but not limited to the GA4GH Data Connect API.
@@ -121,7 +121,7 @@ As with simple objects, DRS clients and servers are expected to agree on the sem
 3. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of leaf objects, and using standard DRS mechanisms to fetch relevant leaf objects.
 
 ### [DEPRECATED] Bundles
-Previous versions of the DRS API spec included support for a *bundle* content type, which like a folder  was a collection of other DRS content (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.*TODO*, bundles have been deprecated in favor of the Compound Object best practice documented above. A future version of the API spec may remove bundle support entirely.
+Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.*TODO*, bundles have been deprecated in favor of the Compound Object best practice documented above. A future version of the API spec may remove bundle support entirely.
 
 ## Read-only
 

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -104,24 +104,24 @@ DRS servers can choose to issue either hostname-based or compact identifier-base
 | Security          | Servers have full control over their own security practices. | Server operators, in addition to maintaining their own security practices, should confirm they are comfortable with the resolver registry security practices, including protection against denial of service and namespace-hijacking attacks. (See the [Appendix: Compact Identifier-Based URIs](#tag/Compact-Identifier-Based-URIs) for more information on resolver registry security.) |
 
 ## DRS Datatypes
+DRS's job is data acccess, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject` represents a single opaque blob of bytes, which (like a file) has no inherent semantic meeting and only simple domain-agnostic metadata. Data organization, discovery, and understanding are left to higher levels of the stack.
 
 ### Simple Objects
-At the API level, DRS v1 has a simple flat content model -- every `DrsObject` represents a single opaque blob of bytes, which (like a file) has no inherent semantic meeting and only simple domain-agnostic metadata. At the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechansisms, including but not limited to the GA4GH Data Connect API. A simple unchanging DRS API can thus support the data access needs of all object types, leaving data discovery and understanding to higher levels of the stack.
+DRS can be used to access objects of all kinds, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechansisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
-Much biomedical data is represented as compound objects consisting of two or more simple objects related to each other in a well-specified way. Examples incluide:
+DRS can also be used to access compound objects, consisting of two or more simple 'leaf' objects related to each other in a well-specified way. Common examples of compound objects in biomedicine incluide:
 * BAM+BAI genomic reads, with a small index (the BAI object) to large data (the BAM object), each object using a well-defined file format.
-* DICOM images, with a contents object pointing to one or more raw image content objects, each containing different aspects of a single logical biomedical image (e.g. different z-coordinates or different pixel resolutions)
-* studies, TODO
+* DICOM images, with a contents object pointing to one or more raw image objects, each containing pixels from different aspects of a single logical biomedical image (e.g. different z-coordinates) <== TODO: check this
+* studies, with a single table of contents listing multiple objects of various types that were generated together and are meant to be processed together
 
-<WIP>
 As with simple objects, DRS clients and servers are expected to agree on the semantics of individual compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
-1. define the syntax of a manifest file, which contains object-specific information about the relationship between the 'leaf' objects, referred to by their DRS IDs
-2. make manifest files available to fetch using standard DRS mechanisms
-3. make leaf objects avilable to fetch using standard DRS mechanisms
-</WIP>
+1. Define a manifest file syntax, which contains a list of the DRS IDs of the leaf objects, plus type-specific information about the relationship between the different elements of the compound object.
+2. Make manifest objects, and each of their referenced leaf objects, available using standard DRS mechanisms -- each manifest and each leaf are referenced via their own DRS IDs, just like any other simple object.
+3. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of leaf objects, and using standard DRS mechanisms to fetch relevant leaf objects.
 
-There is also deprecated support for a *bundle* content type, which like a folder is a collection of other DRS content (either blobs or bundles), represented by a `DrsObject` with a `contents` array.
+### [DEPRECATED] Bundles
+Previous versions of the DRS API spec included support for a *bundle* content type, which like a folder  was a collection of other DRS content (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.*TODO*, bundles have been deprecated in favor of the Compound Object best practice documented above. A future version of the API spec may remove bundle support entirely.
 
 ## Read-only
 

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -110,7 +110,7 @@ DRS's job is data access, period. Therefore, the DRS API supports a simple flat 
 DRS can be used to access individual objects of all kinds, simple or complex, large or small, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on object semantics using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
-DRS can also be used to access compound objects, consisting of two or more atomic objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects) for suggested best practices for working with Compound Objects. 
+DRS can also be used to access compound objects, consisting of two or more atomic objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects) for suggested best practices for working with compound objects. 
 
 ### [DEPRECATED] Bundles
 Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the best practices documented in the [Appendix: Compound Objects](#tag/Working-With-Compound-Objects). A future version of the API spec may remove bundle support entirely.

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -104,13 +104,13 @@ DRS servers can choose to issue either hostname-based or compact identifier-base
 | Security          | Servers have full control over their own security practices. | Server operators, in addition to maintaining their own security practices, should confirm they are comfortable with the resolver registry security practices, including protection against denial of service and namespace-hijacking attacks. (See the [Appendix: Compact Identifier-Based URIs](#tag/Compact-Identifier-Based-URIs) for more information on resolver registry security.) |
 
 ## DRS Datatypes
-DRS's job is data access, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject`, like a file, represents a single opaque blob of bytes. DRS has no understanding of the meaning of objects and only provides simple domain-agnostic metadata. Understanding the semantics of specific object types remains the responsibility of the applications that use DRS to fetch those objects (e.g. samtools for BAM files, DICOM viewers for DICOM objects).
+DRS's job is data access, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject`, like a file, represents a single opaque blob of bytes. DRS has no understanding of the meaning of objects and only provides simple domain-agnostic metadata. Understanding the semantics of specific object types is the responsibility of the applications that use DRS to fetch those objects (e.g. samtools for BAM files, DICOM viewers for DICOM objects).
 
-### Single Objects
-DRS can be used to access objects of all kinds, simple or complex, large or small, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
+### Atomic Objects
+DRS can be used to access individual objects of all kinds, simple or complex, large or small, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on object semantics using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
-DRS can also be used to access compound objects, consisting of two or more single 'leaf' objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Compound-Objects) for suggested best practices for working with Compound Objects. 
+DRS can also be used to access compound objects, consisting of two or more atomic objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Compound-Objects) for suggested best practices for working with Compound Objects. 
 
 ### [DEPRECATED] Bundles
 Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the best practices documented in the [Appendix: Compound Objects](#tag/Compound-Objects). A future version of the API spec may remove bundle support entirely.

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -104,21 +104,13 @@ DRS servers can choose to issue either hostname-based or compact identifier-base
 | Security          | Servers have full control over their own security practices. | Server operators, in addition to maintaining their own security practices, should confirm they are comfortable with the resolver registry security practices, including protection against denial of service and namespace-hijacking attacks. (See the [Appendix: Compact Identifier-Based URIs](#tag/Compact-Identifier-Based-URIs) for more information on resolver registry security.) |
 
 ## DRS Datatypes
-DRS's job is data access, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject` represents a single opaque blob of bytes, which (like a file) has no inherent semantic meaning and only simple domain-agnostic metadata. Data organization, discovery, and understanding are left to higher levels of the stack.
+DRS's job is data access, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject`, like a file, represents a single opaque blob of bytes. DRS has no understanding of the meaning of objects and only provides simple domain-agnostic metadata. Understanding the semantics of specific object types remains the responsibility of the applications that use DRS to fetch those objects (e.g. samtools for BAM files, DICOM viewers for DICOM objects).
 
-### Simple Objects
-DRS can be used to access objects of all kinds, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
+### Single Objects
+DRS can be used to access objects of all kinds, simple or complex, large or small, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
-DRS can also be used to access compound objects, consisting of two or more simple 'leaf' objects related to each other in a well-specified way. Common examples of compound objects in biomedicine include:
-* BAM+BAI genomic reads, with a small index (the BAI object) to large data (the BAM object), each object using a well-defined file format.
-* DICOM images, with a contents object pointing to one or more raw image objects, each containing pixels from different aspects of a single logical biomedical image (e.g. different z-coordinates)
-* studies, with a single table of contents listing multiple objects of various types that were generated together and are meant to be processed together
-
-As with simple objects, DRS clients and servers are expected to agree on the semantics of individual compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
-1. Define a manifest file syntax, which contains a list of the DRS IDs of the leaf objects, plus type-specific information about the relationship between the different elements of the compound object.
-2. Make manifest objects, and each of their referenced leaf objects, available using standard DRS mechanisms -- each manifest and each leaf are referenced via their own DRS IDs, just like any other simple object.
-3. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of leaf objects, and using standard DRS mechanisms to fetch relevant leaf objects.
+DRS can also be used to access compound objects, consisting of two or more single 'leaf' objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Compound-Objects) for suggested best pracitces for working with Compound Objects. 
 
 ### [DEPRECATED] Bundles
 Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the Compound Objects best practice documented above. A future version of the API spec may remove bundle support entirely.

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -110,10 +110,10 @@ DRS's job is data access, period. Therefore, the DRS API supports a simple flat 
 DRS can be used to access objects of all kinds, simple or complex, large or small, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
-DRS can also be used to access compound objects, consisting of two or more single 'leaf' objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Compound-Objects) for suggested best pracitces for working with Compound Objects. 
+DRS can also be used to access compound objects, consisting of two or more single 'leaf' objects related to each other in a well-specified way. See the [Appendix: Compound Objects](#tag/Compound-Objects) for suggested best practices for working with Compound Objects. 
 
 ### [DEPRECATED] Bundles
-Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the Compound Objects best practice documented above. A future version of the API spec may remove bundle support entirely.
+Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the best practices documented in the [Appendix: Compound Objects](#tag/Compound-Objects). A future version of the API spec may remove bundle support entirely.
 
 ## Read-only
 

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -99,16 +99,29 @@ DRS servers can choose to issue either hostname-based or compact identifier-base
 
 |                   | Hostname-based | Compact Identifier-based |
 |-------------------|----------------|--------------------------|
-| URI Durability    | URIs are valid for as long as the server operator maintains ownership of the published DNS address. (They can of course point that address at different physical serving infrastructure as often as they would like.) | URIs are valid for as long as the server operator maintains ownership of the published compact identifier resolver namespace. (They also depend on the meta-resolvers like identifiers.org/n2t.net remaining operational, which is intended to be essentially forever.) |
+| UR \I Durability    | URIs are valid for as long as the server operator maintains ownership of the published DNS address. (They can of course point that address at different physical serving infrastructure as often as they would like.) | URIs are valid for as long as the server operator maintains ownership of the published compact identifier resolver namespace. (They also depend on the meta-resolvers like identifiers.org/n2t.net remaining operational, which is intended to be essentially forever.) |
 | Client Efficiency | URIs require minimal client logic, and no network requests, to resolve. | URIs require small client logic, and 1-2 cacheable network requests, to resolve. |
 | Security          | Servers have full control over their own security practices. | Server operators, in addition to maintaining their own security practices, should confirm they are comfortable with the resolver registry security practices, including protection against denial of service and namespace-hijacking attacks. (See the [Appendix: Compact Identifier-Based URIs](#tag/Compact-Identifier-Based-URIs) for more information on resolver registry security.) |
 
 ## DRS Datatypes
 
-DRS v1 supports two types of content:
+### Simple Objects
+At the API level, DRS v1 has a simple flat content model -- every `DrsObject` represents a single opaque blob of bytes, which (like a file) has no inherent semantic meeting and only simple domain-agnostic metadata. At the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechansisms, including but not limited to the GA4GH Data Connect API. A simple unchanging DRS API can thus support the data access needs of all object types, leaving data discovery and understanding to higher levels of the stack.
 
-* a *blob* is like a file — it’s a single blob of bytes, represented by a `DrsObject` without a `contents` array
-* a *bundle* is like a folder — it’s a collection of other DRS content (either blobs or bundles), represented by a `DrsObject` with a `contents` array
+### Compound Objects
+Much biomedical data is represented as compound objects consisting of two or more simple objects related to each other in a well-specified way. Examples incluide:
+* BAM+BAI genomic reads, with a small index (the BAI object) to large data (the BAM object), each object using a well-defined file format.
+* DICOM images, with a contents object pointing to one or more raw image content objects, each containing different aspects of a single logical biomedical image (e.g. different z-coordinates or different pixel resolutions)
+* studies, TODO
+
+<WIP>
+As with simple objects, DRS clients and servers are expected to agree on the semantics of individual compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
+1. define the syntax of a manifest file, which contains object-specific information about the relationship between the 'leaf' objects, referred to by their DRS IDs
+2. make manifest files available to fetch using standard DRS mechanisms
+3. make leaf objects avilable to fetch using standard DRS mechanisms
+</WIP>
+
+There is also deprecated support for a *bundle* content type, which like a folder is a collection of other DRS content (either blobs or bundles), represented by a `DrsObject` with a `contents` array.
 
 ## Read-only
 

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -2,7 +2,7 @@
 
 Each implementation of DRS can choose its own id scheme, as long as it follows these guidelines:
 
-* DRS IDs are strings made up of uppercase and lowercase letters, decimal digits, hypen, period, underscore and tilde [A-Za-z0-9.-_~]. See [RFC 3986 § 2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
+* DRS IDs are strings made up of uppercase and lowercase letters, decimal digits, hyphen, period, underscore and tilde [A-Za-z0-9.-_~]. See [RFC 3986 § 2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
 * DRS IDs can contain other characters, but they MUST be encoded into valid DRS IDs whenever they are used in API calls. This is because non-encoded IDs may interfere with the interpretation of the objects/{id}/access endpoint. To overcome this limitation use percent-encoding of the ID, see [RFC 3986 § 2.4](https://datatracker.ietf.org/doc/html/rfc3986#section-2.4)
 * One DRS ID MUST always return the same object data (or, in the case of a collection, the same set of objects). This constraint aids with reproducibility.
 * DRS implementations MAY have more than one ID that maps to the same object.
@@ -104,10 +104,10 @@ DRS servers can choose to issue either hostname-based or compact identifier-base
 | Security          | Servers have full control over their own security practices. | Server operators, in addition to maintaining their own security practices, should confirm they are comfortable with the resolver registry security practices, including protection against denial of service and namespace-hijacking attacks. (See the [Appendix: Compact Identifier-Based URIs](#tag/Compact-Identifier-Based-URIs) for more information on resolver registry security.) |
 
 ## DRS Datatypes
-DRS's job is data acccess, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject` represents a single opaque blob of bytes, which (like a file) has no inherent semantic meaning and only simple domain-agnostic metadata. Data organization, discovery, and understanding are left to higher levels of the stack.
+DRS's job is data access, period. Therefore, the DRS API supports a simple flat content model -- every `DrsObject` represents a single opaque blob of bytes, which (like a file) has no inherent semantic meaning and only simple domain-agnostic metadata. Data organization, discovery, and understanding are left to higher levels of the stack.
 
 ### Simple Objects
-DRS can be used to access objects of all kinds, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechansisms, including but not limited to the GA4GH Data Connect API.
+DRS can be used to access objects of all kinds, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechanisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
 DRS can also be used to access compound objects, consisting of two or more simple 'leaf' objects related to each other in a well-specified way. Common examples of compound objects in biomedicine include:
@@ -130,4 +130,4 @@ DRS v1 is a read-only API. We expect that each implementation will define its ow
 ## Standards
 
 The DRS API specification is written in OpenAPI and embodies a RESTful service philosophy. It uses JSON in requests and responses and standard HTTPS on port 443 for information transport.  Optionally, it
-supports authenitcation and authorization using the [GA4GH Passport](https://github.com/ga4gh-duri/ga4gh-duri.github.io/tree/master/researcher_ids) standard.
+supports authentication and authorization using the [GA4GH Passport](https://github.com/ga4gh-duri/ga4gh-duri.github.io/tree/master/researcher_ids) standard.

--- a/openapi/tags/DrsApiPrinciples.md
+++ b/openapi/tags/DrsApiPrinciples.md
@@ -110,9 +110,9 @@ DRS's job is data acccess, period. Therefore, the DRS API supports a simple flat
 DRS can be used to access objects of all kinds, stored in type-specific formats (e.g. BAM files, VCF files, CSV files). At the API level these are all the same; at the application level, DRS clients and servers are expected to agree on the semantics of individual objects using non-DRS mechansisms, including but not limited to the GA4GH Data Connect API.
 
 ### Compound Objects
-DRS can also be used to access compound objects, consisting of two or more simple 'leaf' objects related to each other in a well-specified way. Common examples of compound objects in biomedicine incluide:
+DRS can also be used to access compound objects, consisting of two or more simple 'leaf' objects related to each other in a well-specified way. Common examples of compound objects in biomedicine include:
 * BAM+BAI genomic reads, with a small index (the BAI object) to large data (the BAM object), each object using a well-defined file format.
-* DICOM images, with a contents object pointing to one or more raw image objects, each containing pixels from different aspects of a single logical biomedical image (e.g. different z-coordinates) <== TODO: check this
+* DICOM images, with a contents object pointing to one or more raw image objects, each containing pixels from different aspects of a single logical biomedical image (e.g. different z-coordinates)
 * studies, with a single table of contents listing multiple objects of various types that were generated together and are meant to be processed together
 
 As with simple objects, DRS clients and servers are expected to agree on the semantics of individual compound objects using non-DRS mechanisms. The recommended best practice for representing a particular compound object type is:
@@ -121,7 +121,7 @@ As with simple objects, DRS clients and servers are expected to agree on the sem
 3. Document the expected client logic for processing compound objects of interest. This logic typically consists of using standard DRS mechanisms to fetch the manifest, parsing its syntax, extracting the DRS IDs of leaf objects, and using standard DRS mechanisms to fetch relevant leaf objects.
 
 ### [DEPRECATED] Bundles
-Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the Compound Object best practice documented above. A future version of the API spec may remove bundle support entirely.
+Previous versions of the DRS API spec included support for a *bundle* content type, which was a folder-like collection of other DRS objects (either blobs or bundles), represented by a `DrsObject` with a `contents` array. As of v1.3, bundles have been deprecated in favor of the Compound Objects best practice documented above. A future version of the API spec may remove bundle support entirely.
 
 ## Read-only
 


### PR DESCRIPTION
Per several discussions at our weekly WG meetings, and discussions with driver projects, this PR updates the documentation to say that bundles are deprecated, and to describe best practices for working with simple and compound datatypes in a post-bundle world. (Once merged we'll be able to close out a few open issues around improving bundle support.)

Preview the built docs at https://ga4gh.github.io/data-repository-service-schemas/preview/feature/issue-334-bulk-requests-nobundle-v2/docs/#section/DRS-Datatypes