### PR TITLE
Change implementors to implementers

### DIFF
--- a/openapi/components/schemas/Checksum.yaml
+++ b/openapi/components/schemas/Checksum.yaml
@@ -12,7 +12,7 @@ properties:
       The digest method used to create the checksum.
 
       The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg[IANA Named Information Hash Algorithm Registry].
-      Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
+      Other values MAY be used, as long as implementers are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
 
       GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
       Until then, if implementers do choose such an algorithm (e.g. because it's implemented by their storage provider), they SHOULD use an existing


### PR DESCRIPTION
Hi there,

We're running codespell (https://github.com/codespell-project/codespell) on Galaaxy's public facing API docs, and it complains about implementors.
I saw you've changed one instance of implementors in https://github.com/ga4gh/data-repository-service-schemas/commit/ec561279ba9118e97e407170b0e51efc09ae1ae3 already, so I hope you could also make this change.

Thanks!