### PR TITLE
Feature/issue 395 Indicate object in cold storage

### DIFF
--- a/openapi/components/schemas/AccessMethod.yaml
+++ b/openapi/components/schemas/AccessMethod.yaml
@@ -29,12 +29,12 @@ properties:
     description: >-
       Name of the region in the cloud service provider that the object belongs to.
     example: us-east-1
-  storage:
-    type: string
+  availability:
+    type: boolean
     description: >-
-      Type of storage of file in the cloud.
-      Cold defines that this file is not accessible as its in offline/archival storage.
-    example: cold
+      Availablity of file in the cloud.
+      This label defines if this file is immediately accessible via DRS. Any delay or requirement of thawing mechanism if the file is in offline/archival storage is classified as unavailable.
+    example: true
   authorizations:
     allOf:
       - $ref: './Authorizations.yaml'

--- a/openapi/components/schemas/AccessMethod.yaml
+++ b/openapi/components/schemas/AccessMethod.yaml
@@ -29,11 +29,11 @@ properties:
     description: >-
       Name of the region in the cloud service provider that the object belongs to.
     example: us-east-1
-  availability:
+  available:
     type: boolean
     description: >-
       Availablity of file in the cloud.
-      This label defines if this file is immediately accessible via DRS. Any delay or requirement of thawing mechanism if the file is in offline/archival storage is classified as unavailable.
+      This label defines if this file is immediately accessible via DRS. Any delay or requirement of thawing mechanism if the file is in offline/archival storage is classified as 0 or unavailable.
     example: true
   authorizations:
     allOf:

--- a/openapi/components/schemas/AccessMethod.yaml
+++ b/openapi/components/schemas/AccessMethod.yaml
@@ -29,6 +29,12 @@ properties:
     description: >-
       Name of the region in the cloud service provider that the object belongs to.
     example: us-east-1
+  storage:
+    type: string
+    description: >-
+      Type of storage of file in the cloud.
+      Cold defines that this file is not accessible as its in offline/archival storage.
+    example: cold
   authorizations:
     allOf:
       - $ref: './Authorizations.yaml'


### PR DESCRIPTION
Indicate that a given access method is to cold/offline/less available storage

A DRS object is said to be in 'Cold' storage when it is not immediately available via a DRS request. Hot/Cold is binary. Goal is to indicate that a given access method is to a cold/offline/less available storage. Please see https://github.com/ga4gh/data-repository-service-schemas/issues/395 for community discussion.

We are taking a phased approach. For Phase 1, we just want to answer this question:
Can the user can retrieve the file at the moment of the request?
 - If the user can do that, than the file is in "hot" storage, and can be used right away.
 - If the user cannot retrieve the file, then the file is simply in not available. It is in some form of cold/offline/less available storage.

In phase 2, we can think about having a better way to provide details on the storage and the thawing process.