### PR TITLE
Feature/issue 396 stats endpoint

### DIFF
--- a/openapi/components/responses/200Stats.yaml
+++ b/openapi/components/responses/200Stats.yaml
@@ -1,0 +1,6 @@
+description: Retrieve statistics about the DRS service
+content:
+  application/json:
+    schema:
+      allOf:
+        - '$ref': '../schemas/DrsStats.yaml'

--- a/openapi/components/schemas/DrsStats.yaml
+++ b/openapi/components/schemas/DrsStats.yaml
@@ -1,0 +1,9 @@
+type: object
+description: A statistical summary of files in the DRS service
+properties:
+  fileCount:
+    type: integer
+    description: Number of files contained in DRS service
+  totalFileSize:
+    type: integer
+    description: Aggregate sum of file sizes in DRS service.

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -95,6 +95,7 @@ x-tagGroups:
     tags:
       - Objects
       - Service Info
+      - Stats
   - name: Models
     tags:
       - AccessMethodModel

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -38,6 +38,7 @@ tags:
   # Operations
   - name: Objects
   - name: Service Info
+  - name: Stats
 
   # Models
   - name: AccessMethodModel
@@ -121,6 +122,8 @@ paths:
     $ref: ./paths/objects@{object_id}@access@{access_id}.yaml
   /objects/access:
     $ref: ./paths/bulkobjects@access@{access_id}.yaml
+  /stats
+    $ref: ./paths/stats.yaml
 components:
   securitySchemes:
     BasicAuth:

--- a/openapi/paths/stats.yaml
+++ b/openapi/paths/stats.yaml
@@ -1,0 +1,21 @@
+get:
+  summary: Retrieve stats about this DRS implementation
+  description: |-
+    Returns total file size and number of file statistics from this DRS service
+    
+    e.g.
+    ```
+    {
+        "fileCount": 774560,
+        "totalFileSize": 4018437188907752
+    }
+    ```
+
+  operationId: GetServiceInfo
+  responses:
+    200:
+      $ref: '../components/responses/200Stats.yaml'
+    500:
+      $ref: '../components/responses/500InternalServerError.yaml'
+  tags:
+    - Service Info

--- a/openapi/paths/stats.yaml
+++ b/openapi/paths/stats.yaml
@@ -18,4 +18,4 @@ get:
     500:
       $ref: '../components/responses/500InternalServerError.yaml'
   tags:
-    - Service Info
+    - Stats


### PR DESCRIPTION
see issue https://github.com/ga4gh/data-repository-service-schemas/issues/396

I am proposing adding a `/stats` endpoint to give information about the number of files and total file size of a DRS server.