### PR TITLE
Feature/issue 400 location constraints

### DIFF
--- a/openapi/components/schemas/AccessMethod.yaml
+++ b/openapi/components/schemas/AccessMethod.yaml
@@ -34,7 +34,7 @@ properties:
       - $ref: './Authorizations.yaml'
       - description: When `access_id` is provided, `authorizations` provides information about how to authorize the `/access` method.
   usage_constraints:
-    type: array
+    type: object
     items:
       - $ref: './UsageConstraints.yaml'
       - description: >-

--- a/openapi/components/schemas/AccessMethod.yaml
+++ b/openapi/components/schemas/AccessMethod.yaml
@@ -33,3 +33,10 @@ properties:
     allOf:
       - $ref: './Authorizations.yaml'
       - description: When `access_id` is provided, `authorizations` provides information about how to authorize the `/access` method.
+  usage_constraints:
+	  type: array
+	  items:
+	  	$ref: ‘./UsageConstraints.yaml’
+	  description: >-
+		  This structured metadata allows data providers to clearly communicate their data access and usage policies, ensuring that users are aware of the intended constraints. It also enables data consumers to make informed decisions about how to handle and access the data. The specific values for access_type can be defined in the DRS specification, and they should correspond to the proposed usage policy options. This structure helps promote consistency and interoperability across different implementations of the DRS specification.
+

--- a/openapi/components/schemas/AccessMethod.yaml
+++ b/openapi/components/schemas/AccessMethod.yaml
@@ -34,9 +34,9 @@ properties:
       - $ref: './Authorizations.yaml'
       - description: When `access_id` is provided, `authorizations` provides information about how to authorize the `/access` method.
   usage_constraints:
-	  type: array
-	  items:
-	  	$ref: ‘./UsageConstraints.yaml’
-	  description: >-
-		  This structured metadata allows data providers to clearly communicate their data access and usage policies, ensuring that users are aware of the intended constraints. It also enables data consumers to make informed decisions about how to handle and access the data. The specific values for access_type can be defined in the DRS specification, and they should correspond to the proposed usage policy options. This structure helps promote consistency and interoperability across different implementations of the DRS specification.
+    type: array
+    items:
+      - $ref: './UsageConstraints.yaml'
+      - description: >-
+      This structured metadata allows data providers to clearly communicate their data access and usage policies, ensuring that users are aware of the intended constraints. It also enables data consumers to make informed decisions about how to handle and access the data. The specific values for access_type can be defined in the DRS specification, and they should correspond to the proposed usage policy options. This structure helps promote consistency and interoperability across different implementations of the DRS specification.
 

--- a/openapi/components/schemas/AccessMethod.yaml
+++ b/openapi/components/schemas/AccessMethod.yaml
@@ -37,6 +37,6 @@ properties:
     type: object
     items:
       - $ref: './UsageConstraints.yaml'
-      - description: >-
+    description: >-
       This structured metadata allows data providers to clearly communicate their data access and usage policies, ensuring that users are aware of the intended constraints. It also enables data consumers to make informed decisions about how to handle and access the data. The specific values for access_type can be defined in the DRS specification, and they should correspond to the proposed usage policy options. This structure helps promote consistency and interoperability across different implementations of the DRS specification.
 

--- a/openapi/components/schemas/LocationConstraints.yaml
+++ b/openapi/components/schemas/LocationConstraints.yaml
@@ -1,4 +1,6 @@
 type: object
+required: 
+  - cloud_provider
 properties: 
   cloud_provider:
     type: string

--- a/openapi/components/schemas/LocationConstraints.yaml
+++ b/openapi/components/schemas/LocationConstraints.yaml
@@ -13,4 +13,5 @@ properties:
     type: array
     items: string
     description: specify cloud regions for compute
+    example: us-east-1
     

--- a/openapi/components/schemas/LocationConstraints.yaml
+++ b/openapi/components/schemas/LocationConstraints.yaml
@@ -1,0 +1,14 @@
+type: object
+properties: 
+  cloud_provider:
+    type: string
+    enum: 
+      - aws
+      - gcp
+      - azure
+    description: specify cloud provider for compute
+  cloud_region:
+    type: array
+    items: string
+    description: specify cloud regions for compute
+    

--- a/openapi/components/schemas/UsageConstraints.yaml
+++ b/openapi/components/schemas/UsageConstraints.yaml
@@ -1,4 +1,6 @@
 type: object
+required: 
+  - access_type
 properties:
   access_type:
     type: string

--- a/openapi/components/schemas/UsageConstraints.yaml
+++ b/openapi/components/schemas/UsageConstraints.yaml
@@ -12,5 +12,5 @@ properties:
   location_constraints:
     type: object
     items: 
-      $ref: 'LocationConstraints.yaml'
+      $ref: './LocationConstraints.yaml'
     description: specifies cloud usage

--- a/openapi/components/schemas/UsageConstraints.yaml
+++ b/openapi/components/schemas/UsageConstraints.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  access_type:
+    type: string
+    enum: 
+      - cloud_exclusive
+      - cloud_provider_limited
+      - cloud_region_limited
+    description: represent the intended usage constraints
+  location_constraints:
+    type: object
+    items: 
+      $ref: 'LocationConstraints.yaml'
+    description: specifies cloud usage


### PR DESCRIPTION
usage_constraints is an optional field that specifies how the data owner intends for the data to be used on the cloud.

This spec aims to enhance the GA4GH DRS (Data Repository Service) specification by introducing a new field that provides metadata regarding the intended usage and location constraints for data objects. This additional field will allow data providers to specify their preferences and requirements for how the data should be accessed and utilized. The proposed field will offer the following options:

- Cloud Exclusive (cloud_exclusive): the data object is intended for use exclusively within a cloud environment. Users are expected to access and process the data only within a cloud computing infrastructure and not outside of it; cannot download the data on somebody's laptop

- Cloud Provider-Limited (cloud_provider_limited): the data object should not leave the cloud provider's ecosystem. Users are restricted from moving the data to external locations or platforms. It must remain within the boundaries of the specified cloud provider.

- Cloud Region-Limited (cloud_region_limited): the data object is restricted to a specific cloud region. Users are required to access and process the data within the designated region and are prohibited from transferring it to other geographic locations within the cloud provider's infrastructure.

By introducing this new field, data providers and administrators can communicate their data access and usage policies more effectively, ensuring that data is handled in accordance with their specific requirements. This addition not only enhances the flexibility of the DRS specification but also strengthens data governance and compliance for genomic and health-related data in cloud-based environments.