### PR TITLE
PR to add simple cloud option to access method

### DIFF
--- a/openapi/components/schemas/AccessMethod.yaml
+++ b/openapi/components/schemas/AccessMethod.yaml
@@ -24,6 +24,12 @@ properties:
       An arbitrary string to be passed to the `/access` method to get an `AccessURL`.
       This string must be unique within the scope of a single object.
       Note that at least one of `access_url` and `access_id` must be provided.
+  cloud:
+    type: string
+    description: >-
+      Name of the cloud service provider that the object belongs to.
+      If the cloud service is Amazon Web Services, Google Cloud Platform or Azure the values should be `aws`, `gcp`, or `azure` respectively.
+    example: aws, gcp, or azure
   region:
     type: string
     description: >-


### PR DESCRIPTION
In the Cloud WS meeting on [Aug 12th, 2024](https://docs.google.com/document/d/1hayvWLIoymomPI9oXcaTZirn5YxFv1cYAs70zyvlvnA/edit#bookmark=id.jg4lev1aum29) we decided to simplify the feature described in [Issue #400](https://github.com/ga4gh/data-repository-service-schemas/issues/400) for DRS release 1.5.

The feature branch [feature/issue-400-location-constraints](https://github.com/jared-rozowsky/data-repository-service-schemas/tree/feature/issue-400-location-constraints) ([diff](https://github.com/ga4gh/data-repository-service-schemas/pull/405/files)) and corresponding [PR#405](https://github.com/ga4gh/data-repository-service-schemas/pull/405) looked to add region and cloud constraints to DRS access responses.

This PR, intended for DRS release 1.5, simply adds a string "cloud" to the access response.  We now include cloud, region, and type information only… no cloud or geo location constraint support for example.

The fields we will include are:
- Cloud: e.g. gcp or aws or azure (this is the new field)
- Type: s3 or https or etc
- Region: e.g. us-east-1

After DRS 1.5 we can revisit how we express region, cloud, geo location, etc constraints in DRS which is a much bigger issue.