### PR TITLE
Get by checksum

### DIFF
--- a/openapi/components/parameters/Checksum.yaml
+++ b/openapi/components/parameters/Checksum.yaml
@@ -1,0 +1,6 @@
+in: path
+name: checksum
+required: true
+description: A `checksum` value from the `checksums` list of a `DrsObject`
+schema:
+  type: string

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -196,6 +196,8 @@ paths:
     $ref: ./paths/objects@access.yaml
   /objects/{object_id}/access-methods:
     $ref: ./paths/objects@{object_id}@access-methods.yaml
+  /objects/checksum/{checksum}:
+    $ref: ./paths/objects@checksum@{checksum}.yaml
   /objects/access-methods:
     $ref: ./paths/objects@access-methods.yaml
   /upload-request:

--- a/openapi/paths/objects@checksum@{checksum}.yaml
+++ b/openapi/paths/objects@checksum@{checksum}.yaml
@@ -1,0 +1,29 @@
+get:
+  summary: Get DRS objects that are a match for the checksum.
+  description: >-
+    Returns an array of `DRSObjects` that match a given checksum.
+
+    The checksum type is not provide, the checksum check is done against all checksum types.
+  operationId: GetObjectsByChecksum
+  security:
+    - PassportAuth: []
+  parameters:
+    - $ref: '../components/parameters/Checksum.yaml'
+  responses:
+    200:
+      $ref: '../components/responses/200OkDrsObjects.yaml'
+    202:
+      $ref: '../components/responses/202Accepted.yaml'
+    400:
+      $ref: '../components/responses/400BadRequest.yaml'
+    401:
+      $ref: '../components/responses/401Unauthorized.yaml'
+    403:
+      $ref: '../components/responses/403Forbidden.yaml'
+    404:
+      $ref: '../components/responses/404NotFoundDrsObject.yaml'
+    500:
+      $ref: '../components/responses/500InternalServerError.yaml'
+  tags:
+    - Objects
+  x-swagger-router-controller: ga4gh.drs.server


### PR DESCRIPTION
This adds an additional DRSObject path, to access objects by their checksums.
Being able to access DRSObjects by their checksum is critical for a number of different use cases:

1) A researcher receives a reference from a third party source, and that file has possibly been renamed. They want to see if it has already been catalogued in a DRS server. 
2) Some data management systems (for example [git-lfs](https://git-lfs.com)) use checksums to manage and identify files. Providing a way to identify records by checksum makes it easier to work with these systems (see https://github.com/calypr/git-drs that is currently being developed)