### PR TITLE
Add TES-style tags to DRS objects + filtered listing

### DIFF
--- a/openapi/components/parameters/page_size.yaml
+++ b/openapi/components/parameters/page_size.yaml
@@ -1,0 +1,9 @@
+in: query
+name: page_size
+required: false
+schema:
+  type: integer
+  format: int32
+description: |-
+  Optional number of objects to return in one page.
+  Must be less than 2048. Defaults to 256.

--- a/openapi/components/parameters/page_token.yaml
+++ b/openapi/components/parameters/page_token.yaml
@@ -1,0 +1,9 @@
+in: query
+name: page_token
+required: false
+schema:
+  type: string
+description: |-
+  OPTIONAL. Page token is used to retrieve the next page of results.
+  If unspecified, returns the first page of results. The value can be found
+  in the `next_page_token` field of the last returned result of ListObjects

--- a/openapi/components/parameters/tag_key.yaml
+++ b/openapi/components/parameters/tag_key.yaml
@@ -1,0 +1,34 @@
+in: query
+name: tag_key
+required: false
+schema:
+  type: array
+  items:
+    type: string
+description: |-
+  OPTIONAL. Provide key tag to filter. The field tag_key is an array
+  of key values, and will be zipped with an optional tag_value array.
+  So the query:
+  ```
+    ?tag_key=foo1&tag_value=bar1&tag_key=foo2&tag_value=bar2
+  ```
+  Should be constructed into the structure { "foo1" : "bar1", "foo2" : "bar2"}
+
+  ```
+    ?tag_key=foo1
+  ```
+  Should be constructed into the structure {"foo1" : ""}
+
+  If the tag_value is empty, it will be treated as matching any possible value.
+  If a tag value is provided, both the tag's key and value must be exact
+  matches for an object to be returned.
+  Filter                            Tags                          Match?
+  ----------------------------------------------------------------------
+  {"foo": "bar"}                    {"foo": "bar"}                Yes
+  {"foo": "bar"}                    {"foo": "bat"}                No
+  {"foo": ""}                       {"foo": ""}                   Yes
+  {"foo": "bar", "baz": "bat"}      {"foo": "bar", "baz": "bat"}  Yes
+  {"foo": "bar"}                    {"foo": "bar", "baz": "bat"}  Yes
+  {"foo": "bar", "baz": "bat"}      {"foo": "bar"}                No
+  {"foo": ""}                       {"foo": "bar"}                Yes
+  {"foo": ""}                       {}                            No

--- a/openapi/components/parameters/tag_value.yaml
+++ b/openapi/components/parameters/tag_value.yaml
@@ -1,0 +1,9 @@
+in: query
+name: tag_value
+required: false
+schema:
+  type: array
+  items:
+    type: string
+description: |-
+  OPTIONAL. The companion value field for tag_key

--- a/openapi/components/requestBodies/TagUpdateBody.yaml
+++ b/openapi/components/requestBodies/TagUpdateBody.yaml
@@ -1,0 +1,6 @@
+description: Request body for updating the tags of a DRS object
+required: true
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/TagUpdateRequest.yaml'

--- a/openapi/components/responses/200ListObjects.yaml
+++ b/openapi/components/responses/200ListObjects.yaml
@@ -1,0 +1,7 @@
+description: >-
+  A list of DRS objects matching the request filters, with an optional
+  `next_page_token` to retrieve additional pages.
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/ListObjectsResponse.yaml'

--- a/openapi/components/responses/200TagUpdate.yaml
+++ b/openapi/components/responses/200TagUpdate.yaml
@@ -1,0 +1,7 @@
+description: >-
+  Tags successfully updated. Returns the updated DRS object with the new tags
+  and updated timestamp.
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/DrsObject.yaml'

--- a/openapi/components/schemas/DrsObject.yaml
+++ b/openapi/components/schemas/DrsObject.yaml
@@ -111,3 +111,21 @@ properties:
       about this `DrsObject` from external metadata sources. These
       aliases can be used to represent secondary
       accession numbers or external GUIDs.
+  tags:
+    type: object
+    additionalProperties:
+      type: string
+    example:
+      "WORKFLOW_ID": "cwl-01234"
+      "PROJECT_GROUP": "alice-lab"
+    description: |-
+      A key-value map of arbitrary tags. These can be used to store
+      meta-data and annotations about a `DrsObject`. Example:
+      ```
+      {
+        "tags" : {
+            "WORKFLOW_ID" : "cwl-01234",
+            "PROJECT_GROUP" : "alice-lab"
+        }
+      }
+      ```

--- a/openapi/components/schemas/DrsObjectCandidate.yaml
+++ b/openapi/components/schemas/DrsObjectCandidate.yaml
@@ -85,3 +85,21 @@ properties:
       about this `DrsObject` from external metadata sources. These
       aliases can be used to represent secondary
       accession numbers or external GUIDs.
+  tags:
+    type: object
+    additionalProperties:
+      type: string
+    example:
+      "WORKFLOW_ID": "cwl-01234"
+      "PROJECT_GROUP": "alice-lab"
+    description: |-
+      A key-value map of arbitrary tags. These can be used to store
+      meta-data and annotations about a `DrsObject`. Example:
+      ```
+      {
+        "tags" : {
+            "WORKFLOW_ID" : "cwl-01234",
+            "PROJECT_GROUP" : "alice-lab"
+        }
+      }
+      ```

--- a/openapi/components/schemas/ListObjectsResponse.yaml
+++ b/openapi/components/schemas/ListObjectsResponse.yaml
@@ -1,0 +1,18 @@
+type: object
+required:
+  - resolved_drs_object
+properties:
+  resolved_drs_object:
+    type: array
+    description: |-
+      List of resolved DRS objects. These objects are based on the registered
+      DRS object, but with other fields, such as the `updated_time` timestamp,
+      added/changed by the server.
+    items:
+      $ref: './DrsObject.yaml'
+  next_page_token:
+    type: string
+    description: |-
+      Token used to return the next page of results. This value can be used
+      in the `page_token` field of the next ListObjects request.
+description: ListObjectsResponse describes a response from the ListObjects endpoint.

--- a/openapi/components/schemas/TagUpdateRequest.yaml
+++ b/openapi/components/schemas/TagUpdateRequest.yaml
@@ -1,0 +1,21 @@
+type: object
+required:
+  - tags
+properties:
+  tags:
+    type: object
+    additionalProperties:
+      type: string
+    example:
+      "WORKFLOW_ID": "cwl-01234"
+      "PROJECT_GROUP": "alice-lab"
+    description: |-
+      The new set of tags for the DRS object. This replaces the entire
+      existing tag map. To add or modify individual tags, first retrieve
+      the object, merge the desired changes into its `tags`, and submit the
+      full updated map.
+  passports:
+    type: array
+    items:
+      type: string
+    description: Optional GA4GH Passport JWTs for authorization

--- a/openapi/data_repository_service.openapi.yaml
+++ b/openapi/data_repository_service.openapi.yaml
@@ -68,6 +68,14 @@ tags:
     x-displayName: DrsObjectCandidate
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/DrsObjectCandidate" />
+  - name: ListObjectsResponseModel
+    x-displayName: ListObjectsResponse
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/ListObjectsResponse" />
+  - name: TagUpdateRequestModel
+    x-displayName: TagUpdateRequest
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/TagUpdateRequest" />
   - name: ErrorModel
     x-displayName: Error
     description: |
@@ -156,6 +164,8 @@ x-tagGroups:
       - ContentsObjectModel
       - DrsObjectModel
       - DrsObjectCandidateModel
+      - ListObjectsResponseModel
+      - TagUpdateRequestModel
       - ErrorModel
       - UploadRequestModel
       - UploadResponseModel
@@ -198,6 +208,8 @@ paths:
     $ref: ./paths/objects@{object_id}@access-methods.yaml
   /objects/access-methods:
     $ref: ./paths/objects@access-methods.yaml
+  /objects/{object_id}/tags:
+    $ref: ./paths/objects@{object_id}@tags.yaml
   /upload-request:
     $ref: ./paths/upload-request.yaml
 components:

--- a/openapi/paths/objects.yaml
+++ b/openapi/paths/objects.yaml
@@ -1,3 +1,52 @@
+get:
+  summary: List DRS objects
+  description: >-
+    **Optional Endpoint**: Not all DRS servers support object listing.
+
+    List and filter DRS objects known to the server. This is a server-side
+    discovery capability that complements the bulk `POST /objects` operation
+    (which requires known object IDs).
+
+    Results can be filtered by tag using the `tag_key` and `tag_value` query
+    parameters. Provide one or more `tag_key` values (optionally zipped with
+    `tag_value` values) to match objects whose tags contain all of the
+    specified key/value pairs. A provided `tag_key` with an empty `tag_value`
+    matches any value for that key.
+
+    Results are paginated. If more results are available, the response
+    contains a `next_page_token` that can be passed in the `page_token`
+    query parameter of a subsequent request.
+
+    **Authentication**: A valid GA4GH Passport may be provided, or a bearer
+    token in the header.
+  operationId: ListObjects
+  security:
+    - {}
+    - BasicAuth: []
+    - BearerAuth: []
+    - PassportAuth: []
+  parameters:
+    - $ref: '../components/parameters/tag_key.yaml'
+    - $ref: '../components/parameters/tag_value.yaml'
+    - $ref: '../components/parameters/page_size.yaml'
+    - $ref: '../components/parameters/page_token.yaml'
+  responses:
+    200:
+      $ref: '../components/responses/200ListObjects.yaml'
+    400:
+      $ref: '../components/responses/400BadRequest.yaml'
+    401:
+      $ref: '../components/responses/401Unauthorized.yaml'
+    403:
+      $ref: '../components/responses/403Forbidden.yaml'
+    413:
+      $ref: '../components/responses/413RequestTooLarge.yaml'
+    500:
+      $ref: '../components/responses/500InternalServerError.yaml'
+  tags:
+    - Objects
+  x-swagger-router-controller: ga4gh.drs.server
+
 options:
   summary: Get Authorization info about multiple DrsObjects.
   security:

--- a/openapi/paths/objects@{object_id}@tags.yaml
+++ b/openapi/paths/objects@{object_id}@tags.yaml
@@ -1,0 +1,47 @@
+post:
+  summary: Update tags for a DRS object
+  description: >-
+    **Optional Endpoint**: Not all DRS servers support tag updates.
+
+    Update the tags for an existing DRS object. Only the `tags` map is
+    modified - core object metadata (size, checksums, name, access methods)
+    remains unchanged.
+
+    The `tags` field in the request **replaces** the object's entire existing
+    tag map. If clients want to add or modify only individual tags, they
+    should first retrieve the current object, merge the desired changes into
+    the existing `tags`, and include the full updated map in this request.
+
+    **Authentication**: GA4GH Passports can be provided in the request body.
+  operationId: updateObjectTags
+  parameters:
+    - name: object_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: DRS object identifier
+  requestBody:
+    $ref: '../components/requestBodies/TagUpdateBody.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/200TagUpdate.yaml'
+    '400':
+      $ref: '../components/responses/400BadRequest.yaml'
+    '401':
+      $ref: '../components/responses/401Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/403Forbidden.yaml'
+    '404':
+      $ref: '../components/responses/404NotFoundDrsObject.yaml'
+    '500':
+      $ref: '../components/responses/500InternalServerError.yaml'
+  security:
+    - {}
+    - BasicAuth: []
+    - BearerAuth: []
+    - PassportAuth: []
+  tags:
+    - Objects
+  x-swagger-router-controller: ga4gh.drs.server
+  x-codegen-request-body-name: body


### PR DESCRIPTION
## Summary
Adds first-class tags (key→value map) to DRS objects, plus the ability to list/filter objects by tag and to update an object's tags. Mirrors the well-established TES pattern (tesTask.tags + ListTasks?tag_key=&tag_value=).

All changes are additive and backward-compatible under the existing /v1 + 1.6.0.

## Motivation
DRS currently has no way to attach arbitrary metadata beyond the fixed description/aliases fields, and — more importantly — no list/filter endpoint (/objects is only OPTIONS for auth lookup + POST bulk-fetch by known IDs). tags fills the metadata gap and the new GET /objects is a genuine new discovery capability for clients that don't already know object IDs.

## Changes
1. tags field (metadata)

DrsObject — new optional tags (object, additionalProperties: string), alongside description/aliases.
DrsObjectCandidate — same field, so tags flow automatically through POST /objects/register (no endpoint change needed).
2. New GET /objects — list & filter by tag

ListObjectsResponse schema — resolved_drs_object (array of DrsObject) + next_page_token.
Query params: tag_key / tag_value (array-of-string, positional zip; empty value = "any value for that key"; object must match all supplied pairs) and page_size / page_token for pagination — identical semantics to TES ListTasks.
200ListObjects response + the ListObjects operation wired into the existing /objects path (standard security, tags: [Objects], error responses, x-swagger-router-controller).
3. New POST /objects/{object_id}/tags — update tags

TagUpdateRequest (required tags + optional passports), TagUpdateBody, 200TagUpdate (returns the updated DrsObject), and the updateObjectTags operation.
Semantics = replace the whole tag map (GET-then-merge for partial edits), matching the existing access-method-update pattern.
Path wired in the main data_repository_service.openapi.yaml.
Both new schemas registered in the Models tag list / x-tagGroups.
Notes for reviewers
GET /objects and the tags-update endpoint are documented as Optional Endpoints (not all servers must implement), consistent with the register/update endpoints.

npx @redocly/cli lint on the assembled spec: all new $refs resolve, no dangling references. The only remaining lint findings are pre-existing (2 operation-level examples: struct issues in the delete request bodies, and example-conformance warnings) — none in files touched here.
Manual: DrsObject & DrsObjectCandidate both expose tags; GET /objects and POST /objects/{object_id}/tags render in the generated docs.